### PR TITLE
Unify autoeffect model formula interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/R/model-type-behaviors.R
+++ b/R/model-type-behaviors.R
@@ -173,19 +173,23 @@ get_behavior <- function(model_type) {
 # autoeffect: resolve ae_args and map params
 .prepare_model_args_autoeffect <- function(args, model, model_simulation) {
   ae_args <- resolve_autoeffect_args(model, model_simulation$unit_var, model_simulation$time_var)
-  # Remove optic-specific args
+  # Remove optic-specific args that autoeffect() doesn't accept
   args[["effect_lag"]] <- NULL
   args[["formula"]] <- NULL
-  # Map autoeffect-specific args
+  args[["outcome_name"]] <- NULL
+  args[["unit_name"]] <- NULL
+  args[["date_name"]] <- NULL
+  args[["trt_name"]] <- NULL
+  args[["cov_names"]] <- NULL
+  args[["x_formula"]] <- NULL
+  # Map resolved autoeffect-specific args
   args[["lags"]] <- ae_args$lags
   args[["outcome_name"]] <- ae_args$outcome_name
   args[["unit_name"]] <- ae_args$unit_name
   args[["date_name"]] <- ae_args$date_name
   args[["trt_name"]] <- ae_args$trt_name
-  if (!is.null(ae_args$cov_names)) {
-    args[["cov_names"]] <- ae_args$cov_names
-  } else if ("cov_names" %in% names(args)) {
-    args[["cov_names"]] <- NULL
+  if (!is.null(ae_args$x_formula)) {
+    args[["x_formula"]] <- ae_args$x_formula
   }
   args
 }

--- a/R/optic-model-class.R
+++ b/R/optic-model-class.R
@@ -440,8 +440,9 @@ validate_autoeffect_init <- function(model, data, params) {
     stop("autoeffect models require a treatment indicator specified via 'trt_name'")
   }
   
-  if (!is.null(args$cov_names)) {
-    missing_covs <- setdiff(args$cov_names, names(data))
+  if (!is.null(args$x_formula)) {
+    cov_vars <- all.vars(args$x_formula)
+    missing_covs <- setdiff(cov_vars, names(data))
     if (length(missing_covs) > 0) {
       stop("Covariates missing for autoeffect model: ", paste(missing_covs, collapse = ", "))
     }
@@ -454,28 +455,29 @@ validate_autoeffect_pre_call <- function(model, args) {
   if (length(missing_args) > 0) {
     stop("Missing arguments for autoeffect model: ", paste(missing_args, collapse = ", "))
   }
-  
+
   data <- args$data
   outcome <- args$outcome_name
   unit_name <- args$unit_name
   date_name <- args$date_name
   trt_name <- args$trt_name
-  
+
   if (!all(c(outcome, unit_name, date_name, trt_name) %in% names(data))) {
     stop("Autoeffect model data is missing required columns (outcome, unit, time, or treatment indicator)")
   }
-  
+
   trt_vals <- data[[trt_name]]
   if (!is.numeric(trt_vals) || any(!trt_vals %in% c(0, 1, NA))) {
     stop("Autoeffect treatment indicator '", trt_name, "' must be binary (0/1)")
   }
-  
+
   if (!is.numeric(args$lags) || length(args$lags) != 1 || args$lags < 2) {
     stop("Autoeffect models require 'lags' >= 2")
   }
-  
-  if (!is.null(args$cov_names)) {
-    missing_covs <- setdiff(args$cov_names, names(data))
+
+  if (!is.null(args$x_formula)) {
+    cov_vars <- all.vars(args$x_formula)
+    missing_covs <- setdiff(cov_vars, names(data))
     if (length(missing_covs) > 0) {
       stop("Autoeffect model covariates missing from data: ", paste(missing_covs, collapse = ", "))
     }
@@ -586,9 +588,46 @@ resolve_autoeffect_args <- function(model, unit_var, time_var) {
   args$date_name <- args$date_name %||% time_var
   args$trt_name <- args$trt_name %||% "trt_ind"
   args$lags <- args$lags %||% stop("autoeffect models require a 'lags' argument")
-  args$cov_names <- args$cov_names %||% NULL
-  args$effect_lag <- args$effect_lag %||% args$lags
+  if (!is.null(args$effect_lag) && args$effect_lag != args$lags) {
+    warning("'effect_lag' is deprecated and will be ignored. Using 'lags' = ",
+            args$lags, " for cumulative effect extraction.", call. = FALSE)
+  }
+  args$effect_lag <- args$lags
+
+  # Covariate resolution: formula RHS is the canonical source.
+  # Direct x_formula / cov_names in ... are deprecated.
+  if (!is.null(args$x_formula)) {
+    warning("Passing 'x_formula' directly is deprecated for autoeffect models. ",
+            "Specify covariates in the formula instead (e.g., outcome ~ treatment_level + x1 + x2).",
+            call. = FALSE)
+  } else if (!is.null(args$cov_names)) {
+    warning("Passing 'cov_names' directly is deprecated for autoeffect models. ",
+            "Specify covariates in the formula instead (e.g., outcome ~ treatment_level + x1 + x2).",
+            call. = FALSE)
+    args$x_formula <- stats::as.formula(paste("~", paste(args$cov_names, collapse = " + ")))
+    args$cov_names <- NULL
+  } else {
+    args$x_formula <- .extract_covariates_from_formula(model$model_formula)
+  }
+
   args
+}
+
+#' Extract covariate terms from a two-sided formula, removing treatment variables
+#'
+#' Returns a one-sided formula of non-treatment RHS terms, or NULL if none.
+#' @param fml A two-sided formula
+#' @return A one-sided formula or NULL
+#' @noRd
+.extract_covariates_from_formula <- function(fml) {
+  treatment_terms <- c("treatment_level", "treatment_change", "treatment",
+                       "treatment1_level", "treatment2_level",
+                       "treatment1_change", "treatment2_change")
+  fml_terms <- stats::terms(fml)
+  term_labels <- attr(fml_terms, "term.labels")
+  covariate_terms <- term_labels[!term_labels %in% treatment_terms]
+  if (length(covariate_terms) == 0) return(NULL)
+  stats::as.formula(paste("~", paste(covariate_terms, collapse = " + ")))
 }
 
 `%||%` <- function(x, y) {

--- a/tests/testthat/test-model-autoeffect.R
+++ b/tests/testthat/test-model-autoeffect.R
@@ -21,13 +21,9 @@ test_that("optic_model creates valid autoeffect model", {
     name = "autoeffect_basic",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
-    lags = 2,
-    unit_name = "state",
-    date_name = "year",
-    trt_name = "trt_ind",
-    outcome_name = "crude.rate"
+    lags = 2
   )
 
   expect_s3_class(model, "optic_model")
@@ -42,10 +38,9 @@ test_that("autoeffect model requires lags parameter", {
     name = "autoeffect_lags",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
-    lags = 3,
-    trt_name = "trt_ind"
+    lags = 3
   )
 
   expect_equal(model$model_args$lags, 3)
@@ -58,7 +53,7 @@ test_that("autoeffect model stores trt_name parameter", {
     name = "autoeffect_trt",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
     lags = 2,
     trt_name = "treatment_indicator"
@@ -67,38 +62,117 @@ test_that("autoeffect model stores trt_name parameter", {
   expect_equal(model$model_args$trt_name, "treatment_indicator")
 })
 
-test_that("autoeffect model supports effect_lag parameter", {
+test_that("effect_lag is deprecated and warns when different from lags", {
   skip_if_not_installed("autoeffect")
 
   model <- optic_model(
     name = "autoeffect_effect_lag",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
     lags = 3,
-    effect_lag = 2,
-    trt_name = "trt_ind"
+    effect_lag = 2
   )
 
-  expect_equal(model$model_args$effect_lag, 2)
+  expect_warning(
+    args <- resolve_autoeffect_args(model, "state", "year"),
+    "effect_lag.*deprecated"
+  )
+  expect_equal(args$effect_lag, 3)  # uses lags, not effect_lag
 })
 
-test_that("autoeffect model supports covariates", {
+test_that("covariates extracted from formula RHS", {
   skip_if_not_installed("autoeffect")
 
   model <- optic_model(
-    name = "autoeffect_cov",
+    name = "autoeffect_formula_cov",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level + unemploymentrate,
+    se_adjust = "none",
+    lags = 2
+  )
+
+  args <- resolve_autoeffect_args(model, "state", "year")
+  expect_true(inherits(args$x_formula, "formula"))
+  expect_equal(all.vars(args$x_formula), "unemploymentrate")
+})
+
+test_that("factor covariates preserved in extracted x_formula", {
+  skip_if_not_installed("autoeffect")
+
+  model <- optic_model(
+    name = "autoeffect_factor_cov",
+    type = "autoeffect",
+    call = "autoeffect",
+    formula = crude.rate ~ treatment_level + unemploymentrate + as.factor(year),
+    se_adjust = "none",
+    lags = 2
+  )
+
+  args <- resolve_autoeffect_args(model, "state", "year")
+  expect_true(inherits(args$x_formula, "formula"))
+  formula_str <- deparse(args$x_formula)
+  expect_true(grepl("unemploymentrate", formula_str))
+  expect_true(grepl("as.factor\\(year\\)", formula_str))
+})
+
+test_that("no covariates when formula has only treatment variable", {
+  skip_if_not_installed("autoeffect")
+
+  model <- optic_model(
+    name = "autoeffect_no_cov",
+    type = "autoeffect",
+    call = "autoeffect",
+    formula = crude.rate ~ treatment_level,
+    se_adjust = "none",
+    lags = 2
+  )
+
+  args <- resolve_autoeffect_args(model, "state", "year")
+  expect_null(args$x_formula)
+})
+
+test_that("deprecated cov_names triggers warning and converts to x_formula", {
+  skip_if_not_installed("autoeffect")
+
+  model <- optic_model(
+    name = "autoeffect_deprecated_cov",
+    type = "autoeffect",
+    call = "autoeffect",
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
     lags = 2,
-    trt_name = "trt_ind",
     cov_names = c("unemploymentrate", "population")
   )
 
-  expect_equal(model$model_args$cov_names, c("unemploymentrate", "population"))
+  expect_warning(
+    args <- resolve_autoeffect_args(model, "state", "year"),
+    "cov_names.*deprecated"
+  )
+  expect_true(inherits(args$x_formula, "formula"))
+  expect_null(args$cov_names)
+})
+
+test_that("deprecated x_formula in ... triggers warning", {
+  skip_if_not_installed("autoeffect")
+
+  model <- optic_model(
+    name = "autoeffect_deprecated_xfml",
+    type = "autoeffect",
+    call = "autoeffect",
+    formula = crude.rate ~ treatment_level,
+    se_adjust = "none",
+    lags = 2,
+    x_formula = ~unemploymentrate
+  )
+
+  expect_warning(
+    args <- resolve_autoeffect_args(model, "state", "year"),
+    "x_formula.*deprecated"
+  )
+  expect_true(inherits(args$x_formula, "formula"))
 })
 
 test_that("autoeffect only works with autoeffect call", {
@@ -109,7 +183,7 @@ test_that("autoeffect only works with autoeffect call", {
       name = "autoeffect_invalid",
       type = "autoeffect",
       call = "lm",
-      formula = crude.rate ~ treatment,
+      formula = crude.rate ~ treatment_level,
       se_adjust = "none"
     )
   )
@@ -122,14 +196,9 @@ test_that("end-to-end: autoeffect model runs through dispatch_simulations", {
     name = "autoeffect_e2e",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
-    lags = 2,
-    unit_name = "state",
-    date_name = "year",
-    trt_name = "trt_ind",
-    outcome_name = "crude.rate",
-    effect_lag = 2
+    lags = 2
   )
 
   sim <- optic_simulation(
@@ -157,22 +226,16 @@ test_that("end-to-end: autoeffect model runs through dispatch_simulations", {
   expect_true(all(c("estimate", "se") %in% colnames(results)))
 })
 
-test_that("end-to-end: autoeffect model with covariates", {
+test_that("end-to-end: autoeffect model with covariates in formula", {
   skip_if_not_installed("autoeffect")
 
   model <- optic_model(
     name = "autoeffect_cov_e2e",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level + unemploymentrate,
     se_adjust = "none",
-    lags = 2,
-    unit_name = "state",
-    date_name = "year",
-    trt_name = "trt_ind",
-    outcome_name = "crude.rate",
-    cov_names = "unemploymentrate",
-    effect_lag = 2
+    lags = 2
   )
 
   sim <- optic_simulation(
@@ -207,14 +270,9 @@ test_that("end-to-end: autoeffect model with confounding method", {
     name = "autoeffect_confounding_e2e",
     type = "autoeffect",
     call = "autoeffect",
-    formula = crude.rate ~ treatment,
+    formula = crude.rate ~ treatment_level,
     se_adjust = "none",
-    lags = 2,
-    unit_name = "state",
-    date_name = "year",
-    trt_name = "trt_ind",
-    outcome_name = "crude.rate",
-    effect_lag = 2
+    lags = 2
   )
 
   bias_vals <- list(

--- a/tests/testthat/test-optic_autoeffect_integration.R
+++ b/tests/testthat/test-optic_autoeffect_integration.R
@@ -57,12 +57,7 @@ test_that("autoeffect integration runs alongside TWFE model", {
     call = "autoeffect",
     formula = outcome ~ treatment_level,
     se_adjust = "none",
-    lags = 2,
-    unit_name = "unit",
-    date_name = "year",
-    trt_name = "trt_ind",
-    outcome_name = "outcome",
-    effect_lag = 2
+    lags = 2
   )
 
   sim <- optic_simulation(


### PR DESCRIPTION
## Summary
- Autoeffect models now extract covariates from the formula RHS, matching the interface of reg/autoreg models. Users write `formula = outcome ~ treatment_level + covariate1 + as.factor(year)` and covariates are automatically passed to `autoeffect()` as `x_formula`.
- Deprecated `effect_lag` (now always equals `lags`), `cov_names`, and direct `x_formula` passthrough -- all with deprecation warnings.

-----