### PR TITLE
Read autoeffect p-values from cumulative_effects() output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# optic (development version)
+
+## Bug fixes
+
+* Autoeffect model p-values now use the t-distribution (via `cumulative_effects()`) instead of manually computing with the normal distribution. This fixes inflated Type I error rates for DAR models. ([#38](https://github.com/RANDCorporation/optic/pull/38))
+
 # [optic 1.2.2](https://github.com/RANDCorporation/optic/releases/tag/v1.2.2)
 
 ## New features

--- a/R/model-type-behaviors.R
+++ b/R/model-type-behaviors.R
@@ -300,6 +300,8 @@ get_behavior <- function(model_type) {
   if (!isTRUE(m$convergence) || is.null(cum_effects)) {
     estimate <- NA_real_
     se <- NA_real_
+    t_stat <- NA_real_
+    p_value <- NA_real_
   } else {
     if (!effect_lag %in% cum_effects$Lag) {
       stop("Requested effect_lag = ", effect_lag, " not available in cumulative effects output.")
@@ -307,11 +309,11 @@ get_behavior <- function(model_type) {
     effect_row <- cum_effects[cum_effects$Lag == effect_lag, ]
     estimate <- effect_row$Estimate
     se <- effect_row$StdError
+    t_stat <- effect_row$t_stat
+    p_value <- effect_row$p_value
   }
 
   variance <- se^2
-  t_stat <- ifelse(is.na(se) || se == 0, NA_real_, estimate / se)
-  p_value <- ifelse(is.na(t_stat), NA_real_, 2 * pnorm(abs(t_stat), lower.tail = FALSE))
   mse <- if (!is.null(m$model)) {
     mean(stats::residuals(m$model)^2, na.rm = TRUE)
   } else {
@@ -538,14 +540,14 @@ get_behavior <- function(model_type) {
 
   if (is.null(cum_effects) || !effect_lag %in% cum_effects$Lag) {
     estimate <- NA_real_; se <- NA_real_
+    t_stat <- NA_real_; p_value <- NA_real_
   } else {
     effect_row <- cum_effects[cum_effects$Lag == effect_lag, ]
     estimate <- effect_row$Estimate; se <- effect_row$StdError
+    t_stat <- effect_row$t_stat; p_value <- effect_row$p_value
   }
 
   variance <- se^2
-  t_stat <- ifelse(is.na(se) || se == 0, NA_real_, estimate / se)
-  p_value <- ifelse(is.na(t_stat), NA_real_, 2 * pnorm(abs(t_stat), lower.tail = FALSE))
   mse <- if (!is.null(ae_object$model)) {
     mean(stats::residuals(ae_object$model)^2, na.rm = TRUE)
   } else {


### PR DESCRIPTION
## Summary

Currently `.extract_results_autoeffect()` and `.se_adjust_cluster_autoeffect()` manually compute t-statistics and p-values using `pnorm` (normal distribution). This is incorrect for NLS models and causes inflated Type I error rates for DAR models.

This PR removes the manual computation and reads `t_stat` and `p_value` directly from `cumulative_effects()` output (which now returns them using `pt` with residual df, per RANDCorporation/autoeffect#5).

This mirrors how lm/feols results are handled: the model package computes p-values, optic reads them.

**Depends on:** RANDCorporation/autoeffect#5

## Verification

- [ ] `devtools::test()` passes
- [ ] `R CMD check --as-cran` clean
- [ ] Patch version bumped

-----