### PR TITLE
Power analysis vignette

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/extdata/*.rds filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -30,7 +30,7 @@ jobs:
 #          - {os: ubuntu-latest,   r: 'oldrel-3'}
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PRIVATE_REPO_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:

--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -47,7 +47,6 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, any::knitr, any::rmarkdown, any::testthat, any::fixest
-          dependencies: '"hard"'
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: Full Tests & Coverage (Ubuntu Release)
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PRIVATE_REPO_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       # Enable full model suite tests including augsynth
       OPTIC_FULL_MODEL_SUITE: true
@@ -32,14 +32,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::devtools, any::testthat, any::covr
-          dependencies: '"hard"'
           needs: check
-
-      - name: Install remotes package
-        run: Rscript -e 'install.packages("remotes", repos = "https://cloud.r-project.org")'
-
-      - name: Install augsynth from GitHub
-        run: Rscript -e 'remotes::install_github("ebenmichael/augsynth")'
 
       - name: Run full test suite (including dispatch simulations)
         run: Rscript -e 'devtools::test()'

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -38,10 +38,8 @@ jobs:
       - name: Install remotes package
         run: Rscript -e 'install.packages("remotes", repos = "https://cloud.r-project.org")'
 
-      - name: Install GitHub-only dependencies
-        run: |
-          Rscript -e 'remotes::install_github("ebenmichael/augsynth")'
-          Rscript -e 'remotes::install_github("RANDCorporation/autoeffect")'
+      - name: Install augsynth from GitHub
+        run: Rscript -e 'remotes::install_github("ebenmichael/augsynth")'
 
       - name: Run full test suite (including dispatch simulations)
         run: Rscript -e 'devtools::test()'

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Install remotes package
         run: Rscript -e 'install.packages("remotes", repos = "https://cloud.r-project.org")'
 
-      - name: Install augsynth from GitHub
-        run: Rscript -e 'remotes::install_github("ebenmichael/augsynth")'
+      - name: Install GitHub-only dependencies
+        run: |
+          Rscript -e 'remotes::install_github("ebenmichael/augsynth")'
+          Rscript -e 'remotes::install_github("RANDCorporation/autoeffect")'
 
       - name: Run full test suite (including dispatch simulations)
         run: Rscript -e 'devtools::test()'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -23,6 +23,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -18,7 +18,7 @@ jobs:
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PRIVATE_REPO_PAT || secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
     steps:
@@ -34,9 +34,6 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
-
-      - name: Install augsynth from GitHub for vignettes
-        run: Rscript -e 'if (!requireNamespace("augsynth", quietly = TRUE)) remotes::install_github("ebenmichael/augsynth")'
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -35,10 +35,8 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Install GitHub-only dependencies for vignettes
-        run: |
-          Rscript -e 'if (!requireNamespace("augsynth", quietly = TRUE)) remotes::install_github("ebenmichael/augsynth")'
-          Rscript -e 'if (!requireNamespace("autoeffect", quietly = TRUE)) remotes::install_github("RANDCorporation/autoeffect")'
+      - name: Install augsynth from GitHub for vignettes
+        run: Rscript -e 'if (!requireNamespace("augsynth", quietly = TRUE)) remotes::install_github("ebenmichael/augsynth")'
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -35,6 +35,11 @@ jobs:
           extra-packages: any::pkgdown, local::.
           needs: website
 
+      - name: Install GitHub-only dependencies for vignettes
+        run: |
+          Rscript -e 'if (!requireNamespace("augsynth", quietly = TRUE)) remotes::install_github("ebenmichael/augsynth")'
+          Rscript -e 'if (!requireNamespace("autoeffect", quietly = TRUE)) remotes::install_github("RANDCorporation/autoeffect")'
+
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,8 +49,7 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Remotes:
-    ebenmichael/augsynth,
-    RANDCorporation/autoeffect
+    ebenmichael/augsynth
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,8 @@ Suggests:
     rmarkdown,
     testthat (>= 3.0.0)
 Remotes:
-    ebenmichael/augsynth
+    ebenmichael/augsynth,
+    RANDCorporation/autoeffect
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.4
+Version: 1.2.5
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,12 +41,16 @@ Imports:
     utils
 Suggests:
     augsynth,
+    autoeffect,
     fixest,
     future,
     ggplot2,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
+Remotes:
+    ebenmichael/augsynth,
+    RANDCorporation/autoeffect
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,8 +40,10 @@ Imports:
     tidyr,
     utils
 Suggests:
+    augsynth,
     fixest,
     future,
+    ggplot2,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # optic (development version)
 
+## New features
+
+* Added a power analysis vignette demonstrating simulation-based power analysis for TWFE, debiased AR, ASCM, and CSA estimators using the `overdoses` dataset. Adds `augsynth` and `ggplot2` to `Suggests`. ([#40](https://github.com/RANDCorporation/optic/pull/40))
+
 # [optic 1.2.4](https://github.com/RANDCorporation/optic/releases/tag/v1.2.4)
 
 ## New features

--- a/dev/generate_power_results.R
+++ b/dev/generate_power_results.R
@@ -1,0 +1,83 @@
+# Generate pre-computed simulation results for the power analysis vignette.
+# Run this script from the optic-core directory whenever the vignette
+# parameters change. Output is tracked via git-lfs.
+#
+# Usage: Rscript dev/generate_power_results.R
+
+library(optic)
+library(dplyr)
+library(augsynth)
+library(did)
+library(autoeffect)
+library(future)
+
+data(overdoses)
+
+sim_data <- overdoses %>%
+  filter(!(state %in% c("Nebraska", "Nevada", "Arkansas",
+                         "Mississippi", "Oregon", "South Dakota",
+                         "North Dakota")))
+
+outcome_mean <- mean(sim_data$crude.rate, na.rm = TRUE)
+
+twfe <- optic_model(
+  name = "TWFE", type = "reg", call = "lm",
+  formula = crude.rate ~ as.factor(year) + as.factor(state) +
+    treatment_level + unemploymentrate,
+  se_adjust = "cluster-unit"
+)
+
+csa <- optic_model(
+  name = "CSA", type = "did", call = "att_gt",
+  formula = crude.rate ~ treatment_level,
+  se_adjust = "none",
+  yname = "crude.rate", tname = "year", idname = "state",
+  gname = "treatment_date"
+)
+
+ascm <- optic_model(
+  name = "ASCM", type = "multisynth", call = "multisynth",
+  formula = crude.rate ~ treatment_level,
+  se_adjust = "none",
+  unit = as.name("state"), time = as.name("year"), lambda = 1e-6
+)
+
+debar <- optic_model(
+  name = "Debiased AR", type = "autoeffect", call = "autoeffect",
+  formula = crude.rate ~ treatment_level + unemploymentrate,
+  se_adjust = "cluster-unit", lags = 2
+)
+
+effect_pcts <- c(0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30)
+effect_magnitudes <- as.list(effect_pcts * outcome_mean)
+n_treated <- c(5, 10, 20, 30)
+
+sim <- optic_simulation(
+  x = sim_data,
+  # models = list(twfe, debar, ascm, csa),
+  models = list(twfe, debar, csa),
+  iters = 100,
+  method = "no_confounding",
+  unit_var = "state",
+  treat_var = "state",
+  time_var = "year",
+  effect_magnitude = effect_magnitudes,
+  n_units = n_treated,
+  effect_direction = "neg",
+  policy_speed = "instant",
+  n_implementation_periods = 0,
+  verbose = FALSE
+)
+
+plan(multisession, workers = 6)
+results <- suppressWarnings(
+  dispatch_simulations(
+    sim, use_future = TRUE, seed = 47201, verbose = 1,
+    future.packages = c("optic", "autoeffect", "augsynth", "did", "dplyr")
+  )
+)
+plan(sequential)
+
+if (!dir.exists("inst/extdata")) dir.create("inst/extdata", recursive = TRUE)
+saveRDS(results, "inst/extdata/power_vignette_results.rds")
+cat("Saved:", nrow(results), "rows to inst/extdata/power_vignette_results.rds\n")

--- a/inst/extdata/power_vignette_results.rds
+++ b/inst/extdata/power_vignette_results.rds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56ba0b017e52e670a0358f0542c5661f3df6f0a0c1b50492031c55313126c5fe
+size 269958

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -172,7 +172,12 @@ plan(sequential)
 ```
 
 ```{r load-results, include = FALSE}
-results <- readRDS("../inst/extdata/power_vignette_results.rds")
+rds_path <- system.file("extdata", "power_vignette_results.rds",
+                        package = "optic")
+if (!nzchar(rds_path)) {
+  rds_path <- "../inst/extdata/power_vignette_results.rds"
+}
+results <- readRDS(rds_path)
 ```
 
 ## Summarize results

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -191,8 +191,10 @@ results_filtered <- results %>%
   filter(
     (model_name %in% c("TWFE", "Debiased AR") &
       se_adjustment == "cluster-unit") |
+    # Here "none" means the default standard error provided by each method.
     (model_name %in% c("ASCM", "CSA") & se_adjustment == "none")
   )
+
 
 summary_df <- results_filtered %>%
   group_by(model_name, n_units, effect_magnitude, effect_direction) %>%
@@ -275,20 +277,6 @@ summary_df %>%
   knitr::kable(digits = 3, caption = "Type I error rate by model and N treated")
 ```
 
-## Discussion
-
-Several patterns typically emerge from these comparisons, though the specific results depend on the data and simulation parameters:
-
-- **TWFE** tends to have high power when the number of treated units is moderate to large, but its Type I error can be inflated when treatment timing is staggered and heterogeneous effects are present. In simple settings like this one (with homogeneous, instantaneous effects), TWFE is competitive.
-
-- **Debiased AR** corrects the Nickell bias that afflicts standard autoregressive panel models, producing consistent estimates even in short panels. It tends to be well-powered and well-calibrated, though convergence of the nonlinear least squares estimator can occasionally fail in small samples.
-
-- **ASCM** constructs a synthetic control for each treated unit. It is well-suited to settings with few treated units where pre-treatment fit is important, but its power can be lower than regression-based methods when the number of treated units is large, because inference is based on permutation-like reasoning.
-
-- **CSA** is designed for staggered adoption and provides heterogeneity-robust estimates. Its power depends on the number of distinct treatment cohorts and the pre-treatment comparison periods available.
-
-When choosing among methods, researchers should weigh both power and the validity of each method's identifying assumptions. A method with high power but inflated Type I error will produce misleading results. The power curves above can help researchers determine the minimum detectable effect size for each method under their study's design parameters, which informs decisions about sample size, data granularity, and analytic strategy.
-
 # Conclusion
 
-optic makes it possible to compute power for a range of modern policy evaluation methods using a common simulation-based workflow. This can help researchers compare analytic approaches, assess tradeoffs between different approaches, and plan studies that are better matched to their substantive and methodological goals. Please send comments or questions to: optic@rand.org.
+`optic` makes it possible to compute power for a range of modern policy evaluation methods using a common simulation-based workflow. This can help researchers compare analytic approaches, assess tradeoffs between different approaches, and plan studies that are better matched to their substantive and methodological goals. Please send comments or questions to: optic@rand.org.

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -8,18 +8,11 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
-can_run <- requireNamespace("augsynth", quietly = TRUE) &&
-  requireNamespace("did", quietly = TRUE) &&
-  requireNamespace("autoeffect", quietly = TRUE) &&
-  requireNamespace("ggplot2", quietly = TRUE) &&
-  requireNamespace("future", quietly = TRUE)
-
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
-  fig.height = 5,
-  eval = can_run
+  fig.height = 5
 )
 ```
 
@@ -27,50 +20,46 @@ knitr::opts_chunk$set(
 
 Policy evaluations increasingly rely on modern causal inference and quasi-experimental methods, including designs such as advanced difference-in-differences approaches, synthetic control, and autoregressive models. Although these methods are widely used, power analysis for them can be less straightforward than for standard randomized experiments or simple regression models.
 
-The optic package was designed to help researchers compute statistical power for a range of policy evaluation designs under realistic assumptions about study design, the magnitude of policy effect sizes, the lag or buildup in policy effects over time, and outcome variability. In many settings, simulation-based power analysis is especially valuable because analytic formulas may be unavailable, difficult to derive, or poorly aligned with the design ultimately used in practice.
+Before estimating and interpreting results from their models, researchers using those methods should consider whether policy effects can in practice be recovered given the structure of their data. `optic` helps users do exactly that. The `optic` package helps researchers compute statistical power for a range of policy evaluation designs under realistic assumptions about study design, the magnitude of policy effect sizes, the lag or buildup in policy effects over time, and outcome variability. In many settings, simulation-based power analysis is especially valuable because analytic formulas may be unavailable, difficult to derive, or poorly aligned with the design ultimately used in practice.
 
-This vignette introduces the general workflow for using optic to estimate power across a range of modern policy evaluation methods. We begin with the core logic shared across models, then show how to specify designs, define target estimands, and compute power under alternative assumptions. The goal is to help users move from abstract study plans to transparent, reproducible power calculations.
+This vignette introduces the general workflow for using optic to estimate power across a range of modern policy evaluation methods. We begin introducing the power analysis workflow, then show how to specify designs, define target estimands, and compute power under alternative assumptions. The goal is to help users move from abstract study plans to transparent, reproducible power calculations.
 
-# Core workflow
+# Power analysis workflow
 
-Although the exact syntax varies by model, power analysis in optic generally follows the same steps:
+Although the exact syntax varies by model, power analysis in `optic` follows the same steps:
 
-1. **Specify the study design.** Define the number of treated units, time periods, treatment timing, and clustering structure. The package draws treatment assignment at random from observed panel units, so the user's data implicitly defines the pool of available units and the time span.
+1. **Specify the study design.** Define the number of treated units, time periods, treatment timing, and clustering structure. `optic` assigns treatment at random from observed panel units, so the user's data defines the pool of available units and the time span.
 
-2. **Specify the data-generating process.** State how outcomes behave under the null and alternative hypotheses. This includes the size of the policy effect (as a fraction of the outcome mean), the direction of the effect, and whether the policy takes effect instantly or ramps up over several periods. optic simulates treatment effects directly onto the user's empirical panel data, preserving the outcome's natural variability, serial correlation, and cross-sectional heterogeneity.
+2. **Specify the data-generating process.** State how outcomes behave under the null and alternative hypotheses. This includes the size of the policy effect (as a fraction of the outcome mean), the direction of the effect, and whether the policy takes effect instantly or ramps up over several periods. `optic` simulates treatment effects directly onto the user's empirical panel data, preserving the outcome's natural variability, serial correlation, and cross-sectional heterogeneity.
 
-3. **Choose the policy evaluation approaches.** Select estimators that match the planned analysis. optic supports:
+3. **Choose a set of estimators.** Select estimators that match the planned analysis. `optic` supports:
     - Two-way fixed effects (TWFE) regression via `lm` or `feols`
-    - Autoregressive (AR) models that include a lagged dependent variable
     - Augmented synthetic control (ASCM) via the `augsynth` package
     - Callaway and Sant'Anna (CSA) group-time ATT via the `did` package
     - Debiased autoregressive models via the `autoeffect` package
 
-4. **Simulate repeated datasets.** For each combination of design parameters (number of treated units, effect size, model), optic generates many synthetic datasets by randomly assigning treatment and adding the specified effect. Each dataset is analyzed with each model, producing point estimates, standard errors, and p-values.
+4. **Simulate repeated datasets.** For each combination of design parameters (number of treated units, effect size, model), optic generates many synthetic datasets by randomly assigning treatment and adding the policy effect specified by the user. `optic` then uses each user-specified model to estimate policy effects, and returns simulation results including point estimates, standard errors, and p-values.
 
-5. **Estimate power.** Power is the proportion of simulated datasets in which the null hypothesis is rejected correctly. For non-null effects, we define power as the fraction of iterations where the model both rejects at the chosen significance level *and* recovers the correct sign of the effect. This guards against scenarios where a method rejects frequently but with the wrong sign (Type S error).
+5. **Estimate power.** Power is the proportion of simulated datasets in which the null hypothesis is rejected correctly. For non-null effects, power is the fraction of iterations where the model both rejects at the chosen significance level *and* recovers the correct sign of the effect. This guards against scenarios where a method rejects frequently but with the wrong sign (Type S error).
 
 This workflow lets users align power calculations with the substantive features of their policy setting, including how quickly a policy is expected to affect outcomes.
 
-# An example: comparing power for TWFE, Debiased AR, ASCM, and CSA
+# Worked Example: comparing power for ASCM, CSA, TWFE, and Debiased AR
 
-We illustrate the workflow using the `overdoses` dataset shipped with optic, which contains state-year panel data on drug overdose crude death rates, unemployment, and population for 51 U.S. states from 1999 to 2017.
+We illustrate the workflow above using the `overdoses` dataset shipped with optic, which contains state-year panel data on drug overdose crude death rates, unemployment, and population for 51 U.S. states from 1999 to 2017.
 
-## Setup
+## Data
+
+A key requirement of the package is that it receives balanced, repeated-measures panel data on the outcome with no missing values. We drop a handful of states that cause numerical issues with augmented synthetic control, consistent with common practice when balancing the donor pool.
 
 ```{r setup, message = FALSE, warning = FALSE}
 library(optic)
 library(dplyr)
 library(tidyr)
 library(ggplot2)
-library(augsynth)
-library(did)
-library(autoeffect)
 
 data(overdoses)
 ```
-
-A key requirement of the package is that it receives balanced, repeated-measures panel data on the outcome with no missing values. We drop a handful of states that cause numerical issues with augmented synthetic control, consistent with common practice when balancing the donor pool.
 
 ```{r data-prep}
 sim_data <- overdoses %>%
@@ -86,41 +75,25 @@ cat("Years:", paste(range(sim_data$year), collapse = "-"), "\n")
 
 ## Define models
 
-We specify four models that represent distinct analytic traditions in policy evaluation:
+We specify four models that represent distinct analytic traditions in policy evaluation using the `optic_model` function. Here we study four models:
 
 - **TWFE**: Two-way fixed effects regression with unit and time fixed effects, cluster-robust standard errors at the state level.
 - **Debiased AR**: Debiased autoregressive model via the `autoeffect` package, which removes the bias inherent in standard autoregressive panel models by using Nickell-bias-corrected estimates. We include an unemployment rate covariate and use 2 lags for cumulative effect estimation, with cluster-robust standard errors.
 - **ASCM**: Augmented synthetic control, which reweights untreated units to match pre-treatment trends.
 - **CSA**: Callaway and Sant'Anna's group-time ATT estimator, designed for staggered adoption settings.
 
-```{r define-models}
+```{r define-models, eval = FALSE}
+library(augsynth)
+library(did)
+library(autoeffect)
+
 twfe <- optic_model(
   name = "TWFE",
   type = "reg",
   call = "lm",
   formula = crude.rate ~ as.factor(year) + as.factor(state) +
-    treatment_level,
+    treatment_level + unemploymentrate,
   se_adjust = "cluster-unit"
-)
-
-debar <- optic_model(
-  name = "Debiased AR",
-  type = "autoeffect",
-  call = "autoeffect",
-  formula = crude.rate ~ treatment_level + unemploymentrate,
-  se_adjust = "cluster-unit",
-  lags = 2
-)
-
-ascm <- optic_model(
-  name = "ASCM",
-  type = "multisynth",
-  call = "multisynth",
-  formula = crude.rate ~ treatment_level,
-  se_adjust = "none",
-  unit = as.name("state"),
-  time = as.name("year"),
-  lambda = 1e-6
 )
 
 csa <- optic_model(
@@ -134,6 +107,26 @@ csa <- optic_model(
   idname = "state",
   gname = "treatment_date"
 )
+
+ascm <- optic_model(
+  name = "ASCM",
+  type = "multisynth",
+  call = "multisynth",
+  formula = crude.rate ~ treatment_level,
+  se_adjust = "none",
+  unit = as.name("state"),
+  time = as.name("year"),
+  lambda = 1e-6
+)
+
+debar <- optic_model(
+  name = "Debiased AR",
+  type = "autoeffect",
+  call = "autoeffect",
+  formula = crude.rate ~ treatment_level + unemploymentrate,
+  se_adjust = "cluster-unit",
+  lags = 2
+)
 ```
 
 ## Configure and run simulations
@@ -143,18 +136,19 @@ We vary two design parameters:
 - **Number of treated units** ($N_{trt}$): 5, 10, 20, 30. This reflects settings ranging from a handful of early-adopter states to a majority of the panel.
 - **Effect size**: 5%, 10%, 15%, 20%, 25%, 30% reductions in the outcome mean. A null effect (0%) is included for Type I error calibration.
 
-All effects are instantaneous and negative (consistent with a policy intended to reduce overdose deaths). We use a modest number of iterations here to keep build time manageable; for real applications, 500--1000 iterations are recommended.
+All effects are instantaneous and negative (consistent with a policy intended to reduce overdose deaths). For real applications, 500--1000 iterations are recommended.
 
-```{r configure-sim, message = FALSE}
+```{r configure-and-run, eval = FALSE}
+library(future)
+
 effect_pcts <- c(0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30)
 effect_magnitudes <- as.list(effect_pcts * outcome_mean)
 n_treated <- c(5, 10, 20, 30)
-n_iters <- 100
 
 sim <- optic_simulation(
   x = sim_data,
   models = list(twfe, debar, ascm, csa),
-  iters = n_iters,
+  iters = 100,
   method = "no_confounding",
   unit_var = "state",
   treat_var = "state",
@@ -166,27 +160,28 @@ sim <- optic_simulation(
   n_implementation_periods = 0,
   verbose = FALSE
 )
-```
 
-```{r run-sim, message = FALSE, warning = FALSE}
-library(future)
 plan(multisession, workers = 6)
 
-results <- suppressWarnings(
-  dispatch_simulations(
-    sim, use_future = TRUE, seed = 47201, verbose = 0,
-    future.packages = c("optic", "autoeffect", "augsynth", "did", "dplyr")
-  )
+results <- dispatch_simulations(
+  sim, use_future = TRUE, seed = 47201, verbose = 0,
+  future.packages = c("optic", "autoeffect", "augsynth", "did", "dplyr")
 )
 
 plan(sequential)
 ```
 
+```{r load-results, include = FALSE}
+results <- readRDS("../inst/extdata/power_vignette_results.rds")
+```
+
 ## Summarize results
 
-For each combination of model, effect size, and number of treated units, we compute the rejection rate, Type S error, and correct-direction power. For TWFE and AR, which produce both unadjusted and cluster-robust results, we keep only the cluster-robust rows. ASCM and CSA report a single SE adjustment ("none"), which is their default inference.
+For each combination of model, effect size, and number of treated units, we compute the rejection rate, Type S error, and correct-direction power. For TWFE and Debiased AR, which produce both unadjusted and cluster-robust results, we keep only the cluster-robust rows. ASCM and CSA report a single SE adjustment ("none"), which is their default inference.
 
 ```{r summarize}
+available_models <- unique(results$model_name)
+
 results_filtered <- results %>%
   filter(
     (model_name %in% c("TWFE", "Debiased AR") &
@@ -212,7 +207,10 @@ summary_df <- results_filtered %>%
   ) %>%
   mutate(
     effect_pct = round(effect_magnitude / outcome_mean * 100),
-    n_units_label = paste0("N treated = ", n_units),
+    n_units_label = factor(
+      paste0("N treated = ", n_units),
+      levels = paste0("N treated = ", sort(unique(n_units)))
+    ),
     power = ifelse(
       effect_magnitude == 0,
       rejection_rate,
@@ -226,10 +224,13 @@ summary_df <- results_filtered %>%
 The figure below shows correct-direction power as a function of effect size, faceted by the number of treated units. The horizontal dashed line marks the conventional 80% power threshold.
 
 ```{r power-curves, fig.width = 8, fig.height = 6}
-model_colors <- c(
+all_colors <- c(
   "TWFE" = "#2166AC", "Debiased AR" = "#B2182B",
   "ASCM" = "#1B7837", "CSA" = "#762A83"
 )
+all_shapes <- c("TWFE" = 16, "Debiased AR" = 17, "ASCM" = 15, "CSA" = 18)
+model_colors <- all_colors[names(all_colors) %in% available_models]
+model_shapes <- all_shapes[names(all_shapes) %in% available_models]
 
 ggplot(
   summary_df,
@@ -241,10 +242,7 @@ ggplot(
   geom_hline(yintercept = 0.80, linetype = "dashed", color = "gray50") +
   facet_wrap(~n_units_label, nrow = 1) +
   scale_color_manual(values = model_colors, name = NULL) +
-  scale_shape_manual(
-    values = c("TWFE" = 16, "Debiased AR" = 17, "ASCM" = 15, "CSA" = 18),
-    name = NULL
-  ) +
+  scale_shape_manual(values = model_shapes, name = NULL) +
   scale_x_continuous(breaks = unique(summary_df$effect_pct)) +
   scale_y_continuous(limits = c(0, 1)) +
   labs(

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -8,11 +8,18 @@ vignette: >
 ---
 
 ```{r, include = FALSE}
+can_run <- requireNamespace("augsynth", quietly = TRUE) &&
+  requireNamespace("did", quietly = TRUE) &&
+  requireNamespace("autoeffect", quietly = TRUE) &&
+  requireNamespace("ggplot2", quietly = TRUE) &&
+  requireNamespace("future", quietly = TRUE)
+
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
   fig.width = 7,
-  fig.height = 5
+  fig.height = 5,
+  eval = can_run
 )
 ```
 
@@ -45,7 +52,7 @@ Although the exact syntax varies by model, power analysis in optic generally fol
 
 This workflow lets users align power calculations with the substantive features of their policy setting, including how quickly a policy is expected to affect outcomes.
 
-# An example: comparing power for TWFE, AR, ASCM, and CSA
+# An example: comparing power for TWFE, Debiased AR, ASCM, and CSA
 
 We illustrate the workflow using the `overdoses` dataset shipped with optic, which contains state-year panel data on drug overdose crude death rates, unemployment, and population for 51 U.S. states from 1999 to 2017.
 
@@ -58,6 +65,7 @@ library(tidyr)
 library(ggplot2)
 library(augsynth)
 library(did)
+library(autoeffect)
 
 data(overdoses)
 ```
@@ -81,7 +89,7 @@ cat("Years:", paste(range(sim_data$year), collapse = "-"), "\n")
 We specify four models that represent distinct analytic traditions in policy evaluation:
 
 - **TWFE**: Two-way fixed effects regression with unit and time fixed effects, cluster-robust standard errors at the state level.
-- **AR**: Autoregressive model with a lagged dependent variable and year fixed effects, cluster-robust standard errors.
+- **Debiased AR**: Debiased autoregressive model via the `autoeffect` package, which removes the bias inherent in standard autoregressive panel models by using Nickell-bias-corrected estimates. We include an unemployment rate covariate and use 2 lags for cumulative effect estimation, with cluster-robust standard errors.
 - **ASCM**: Augmented synthetic control, which reweights untreated units to match pre-treatment trends.
 - **CSA**: Callaway and Sant'Anna's group-time ATT estimator, designed for staggered adoption settings.
 
@@ -95,13 +103,13 @@ twfe <- optic_model(
   se_adjust = "cluster-unit"
 )
 
-ar <- optic_model(
-  name = "AR",
-  type = "autoreg",
-  call = "lm",
-  formula = crude.rate ~ unemploymentrate + as.factor(year) +
-    treatment_change,
-  se_adjust = "cluster-unit"
+debar <- optic_model(
+  name = "Debiased AR",
+  type = "autoeffect",
+  call = "autoeffect",
+  formula = crude.rate ~ treatment_level + unemploymentrate,
+  se_adjust = "cluster-unit",
+  lags = 2
 )
 
 ascm <- optic_model(
@@ -145,7 +153,7 @@ n_iters <- 100
 
 sim <- optic_simulation(
   x = sim_data,
-  models = list(twfe, ar, ascm, csa),
+  models = list(twfe, debar, ascm, csa),
   iters = n_iters,
   method = "no_confounding",
   unit_var = "state",
@@ -167,7 +175,7 @@ plan(multisession, workers = 6)
 results <- suppressWarnings(
   dispatch_simulations(
     sim, use_future = TRUE, seed = 47201, verbose = 0,
-    future.packages = c("optic", "augsynth", "did", "dplyr")
+    future.packages = c("optic", "autoeffect", "augsynth", "did", "dplyr")
   )
 )
 
@@ -181,7 +189,8 @@ For each combination of model, effect size, and number of treated units, we comp
 ```{r summarize}
 results_filtered <- results %>%
   filter(
-    (model_name %in% c("TWFE", "AR") & se_adjustment == "cluster-unit") |
+    (model_name %in% c("TWFE", "Debiased AR") &
+      se_adjustment == "cluster-unit") |
     (model_name %in% c("ASCM", "CSA") & se_adjustment == "none")
   )
 
@@ -218,7 +227,7 @@ The figure below shows correct-direction power as a function of effect size, fac
 
 ```{r power-curves, fig.width = 8, fig.height = 6}
 model_colors <- c(
-  "TWFE" = "#2166AC", "AR" = "#B2182B",
+  "TWFE" = "#2166AC", "Debiased AR" = "#B2182B",
   "ASCM" = "#1B7837", "CSA" = "#762A83"
 )
 
@@ -233,7 +242,7 @@ ggplot(
   facet_wrap(~n_units_label, nrow = 1) +
   scale_color_manual(values = model_colors, name = NULL) +
   scale_shape_manual(
-    values = c("TWFE" = 16, "AR" = 17, "ASCM" = 15, "CSA" = 18),
+    values = c("TWFE" = 16, "Debiased AR" = 17, "ASCM" = 15, "CSA" = 18),
     name = NULL
   ) +
   scale_x_continuous(breaks = unique(summary_df$effect_pct)) +
@@ -269,7 +278,7 @@ Several patterns typically emerge from these comparisons, though the specific re
 
 - **TWFE** tends to have high power when the number of treated units is moderate to large, but its Type I error can be inflated when treatment timing is staggered and heterogeneous effects are present. In simple settings like this one (with homogeneous, instantaneous effects), TWFE is competitive.
 
-- **AR** models trade some power for robustness to pre-treatment trends by conditioning on lagged outcomes. They can be underpowered when the lagged outcome absorbs much of the variation that would otherwise identify the treatment effect.
+- **Debiased AR** corrects the Nickell bias that afflicts standard autoregressive panel models, producing consistent estimates even in short panels. It tends to be well-powered and well-calibrated, though convergence of the nonlinear least squares estimator can occasionally fail in small samples.
 
 - **ASCM** constructs a synthetic control for each treated unit. It is well-suited to settings with few treated units where pre-treatment fit is important, but its power can be lower than regression-based methods when the number of treated units is large, because inference is based on permutation-like reasoning.
 

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -1,0 +1,282 @@
+---
+title: "Power Analysis with optic"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Power Analysis with optic}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 7,
+  fig.height = 5
+)
+```
+
+# Overview
+
+Policy evaluations increasingly rely on modern causal inference and quasi-experimental methods, including designs such as advanced difference-in-differences approaches, synthetic control, and autoregressive models. Although these methods are widely used, power analysis for them can be less straightforward than for standard randomized experiments or simple regression models.
+
+The optic package was designed to help researchers compute statistical power for a range of policy evaluation designs under realistic assumptions about study design, the magnitude of policy effect sizes, the lag or buildup in policy effects over time, and outcome variability. In many settings, simulation-based power analysis is especially valuable because analytic formulas may be unavailable, difficult to derive, or poorly aligned with the design ultimately used in practice.
+
+This vignette introduces the general workflow for using optic to estimate power across a range of modern policy evaluation methods. We begin with the core logic shared across models, then show how to specify designs, define target estimands, and compute power under alternative assumptions. The goal is to help users move from abstract study plans to transparent, reproducible power calculations.
+
+# Core workflow
+
+Although the exact syntax varies by model, power analysis in optic generally follows the same steps:
+
+1. **Specify the study design.** Define the number of treated units, time periods, treatment timing, and clustering structure. The package draws treatment assignment at random from observed panel units, so the user's data implicitly defines the pool of available units and the time span.
+
+2. **Specify the data-generating process.** State how outcomes behave under the null and alternative hypotheses. This includes the size of the policy effect (as a fraction of the outcome mean), the direction of the effect, and whether the policy takes effect instantly or ramps up over several periods. optic simulates treatment effects directly onto the user's empirical panel data, preserving the outcome's natural variability, serial correlation, and cross-sectional heterogeneity.
+
+3. **Choose the policy evaluation approaches.** Select estimators that match the planned analysis. optic supports:
+    - Two-way fixed effects (TWFE) regression via `lm` or `feols`
+    - Autoregressive (AR) models that include a lagged dependent variable
+    - Augmented synthetic control (ASCM) via the `augsynth` package
+    - Callaway and Sant'Anna (CSA) group-time ATT via the `did` package
+    - Debiased autoregressive models via the `autoeffect` package
+
+4. **Simulate repeated datasets.** For each combination of design parameters (number of treated units, effect size, model), optic generates many synthetic datasets by randomly assigning treatment and adding the specified effect. Each dataset is analyzed with each model, producing point estimates, standard errors, and p-values.
+
+5. **Estimate power.** Power is the proportion of simulated datasets in which the null hypothesis is rejected correctly. For non-null effects, we define power as the fraction of iterations where the model both rejects at the chosen significance level *and* recovers the correct sign of the effect. This guards against scenarios where a method rejects frequently but with the wrong sign (Type S error).
+
+This workflow lets users align power calculations with the substantive features of their policy setting, including how quickly a policy is expected to affect outcomes.
+
+# An example: comparing power for TWFE, AR, ASCM, and CSA
+
+We illustrate the workflow using the `overdoses` dataset shipped with optic, which contains state-year panel data on drug overdose crude death rates, unemployment, and population for 51 U.S. states from 1999 to 2017.
+
+## Setup
+
+```{r setup, message = FALSE, warning = FALSE}
+library(optic)
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+library(augsynth)
+library(did)
+
+data(overdoses)
+```
+
+A key requirement of the package is that it receives balanced, repeated-measures panel data on the outcome with no missing values. We drop a handful of states that cause numerical issues with augmented synthetic control, consistent with common practice when balancing the donor pool.
+
+```{r data-prep}
+sim_data <- overdoses %>%
+  filter(!(state %in% c("Nebraska", "Nevada", "Arkansas",
+                         "Mississippi", "Oregon", "South Dakota",
+                         "North Dakota")))
+
+outcome_mean <- mean(sim_data$crude.rate, na.rm = TRUE)
+cat("Outcome mean (crude death rate per 100k):", round(outcome_mean, 2), "\n")
+cat("States:", length(unique(sim_data$state)), "\n")
+cat("Years:", paste(range(sim_data$year), collapse = "-"), "\n")
+```
+
+## Define models
+
+We specify four models that represent distinct analytic traditions in policy evaluation:
+
+- **TWFE**: Two-way fixed effects regression with unit and time fixed effects, cluster-robust standard errors at the state level.
+- **AR**: Autoregressive model with a lagged dependent variable and year fixed effects, cluster-robust standard errors.
+- **ASCM**: Augmented synthetic control, which reweights untreated units to match pre-treatment trends.
+- **CSA**: Callaway and Sant'Anna's group-time ATT estimator, designed for staggered adoption settings.
+
+```{r define-models}
+twfe <- optic_model(
+  name = "TWFE",
+  type = "reg",
+  call = "lm",
+  formula = crude.rate ~ as.factor(year) + as.factor(state) +
+    treatment_level,
+  se_adjust = "cluster-unit"
+)
+
+ar <- optic_model(
+  name = "AR",
+  type = "autoreg",
+  call = "lm",
+  formula = crude.rate ~ unemploymentrate + as.factor(year) +
+    treatment_change,
+  se_adjust = "cluster-unit"
+)
+
+ascm <- optic_model(
+  name = "ASCM",
+  type = "multisynth",
+  call = "multisynth",
+  formula = crude.rate ~ treatment_level,
+  se_adjust = "none",
+  unit = as.name("state"),
+  time = as.name("year"),
+  lambda = 1e-6
+)
+
+csa <- optic_model(
+  name = "CSA",
+  type = "did",
+  call = "att_gt",
+  formula = crude.rate ~ treatment_level,
+  se_adjust = "none",
+  yname = "crude.rate",
+  tname = "year",
+  idname = "state",
+  gname = "treatment_date"
+)
+```
+
+## Configure and run simulations
+
+We vary two design parameters:
+
+- **Number of treated units** ($N_{trt}$): 5, 10, 20, 30. This reflects settings ranging from a handful of early-adopter states to a majority of the panel.
+- **Effect size**: 5%, 10%, 15%, 20%, 25%, 30% reductions in the outcome mean. A null effect (0%) is included for Type I error calibration.
+
+All effects are instantaneous and negative (consistent with a policy intended to reduce overdose deaths). We use a modest number of iterations here to keep build time manageable; for real applications, 500--1000 iterations are recommended.
+
+```{r configure-sim, message = FALSE}
+effect_pcts <- c(0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30)
+effect_magnitudes <- as.list(effect_pcts * outcome_mean)
+n_treated <- c(5, 10, 20, 30)
+n_iters <- 100
+
+sim <- optic_simulation(
+  x = sim_data,
+  models = list(twfe, ar, ascm, csa),
+  iters = n_iters,
+  method = "no_confounding",
+  unit_var = "state",
+  treat_var = "state",
+  time_var = "year",
+  effect_magnitude = effect_magnitudes,
+  n_units = n_treated,
+  effect_direction = "neg",
+  policy_speed = "instant",
+  n_implementation_periods = 0,
+  verbose = FALSE
+)
+```
+
+```{r run-sim, message = FALSE, warning = FALSE}
+library(future)
+plan(multisession, workers = 6)
+
+results <- suppressWarnings(
+  dispatch_simulations(
+    sim, use_future = TRUE, seed = 47201, verbose = 0,
+    future.packages = c("optic", "augsynth", "did", "dplyr")
+  )
+)
+
+plan(sequential)
+```
+
+## Summarize results
+
+For each combination of model, effect size, and number of treated units, we compute the rejection rate, Type S error, and correct-direction power. For TWFE and AR, which produce both unadjusted and cluster-robust results, we keep only the cluster-robust rows. ASCM and CSA report a single SE adjustment ("none"), which is their default inference.
+
+```{r summarize}
+results_filtered <- results %>%
+  filter(
+    (model_name %in% c("TWFE", "AR") & se_adjustment == "cluster-unit") |
+    (model_name %in% c("ASCM", "CSA") & se_adjustment == "none")
+  )
+
+summary_df <- results_filtered %>%
+  group_by(model_name, n_units, effect_magnitude, effect_direction) %>%
+  summarize(
+    rejection_rate = sim_rejection_rate(p_value),
+    type_s_error = sim_type_s_error(
+      estimate, p_value,
+      true_effect = if (first(effect_direction) == "neg") {
+        -first(effect_magnitude)
+      } else {
+        first(effect_magnitude)
+      }
+    ),
+    mean_estimate = mean(estimate, na.rm = TRUE),
+    mean_se = mean(se, na.rm = TRUE),
+    .groups = "drop"
+  ) %>%
+  mutate(
+    effect_pct = round(effect_magnitude / outcome_mean * 100),
+    n_units_label = paste0("N treated = ", n_units),
+    power = ifelse(
+      effect_magnitude == 0,
+      rejection_rate,
+      rejection_rate * (1 - type_s_error)
+    )
+  )
+```
+
+## Power curves
+
+The figure below shows correct-direction power as a function of effect size, faceted by the number of treated units. The horizontal dashed line marks the conventional 80% power threshold.
+
+```{r power-curves, fig.width = 8, fig.height = 6}
+model_colors <- c(
+  "TWFE" = "#2166AC", "AR" = "#B2182B",
+  "ASCM" = "#1B7837", "CSA" = "#762A83"
+)
+
+ggplot(
+  summary_df,
+  aes(x = effect_pct, y = power, color = model_name,
+      shape = model_name, group = model_name)
+) +
+  geom_line(linewidth = 0.8) +
+  geom_point(size = 2.5) +
+  geom_hline(yintercept = 0.80, linetype = "dashed", color = "gray50") +
+  facet_wrap(~n_units_label, nrow = 1) +
+  scale_color_manual(values = model_colors, name = NULL) +
+  scale_shape_manual(
+    values = c("TWFE" = 16, "AR" = 17, "ASCM" = 15, "CSA" = 18),
+    name = NULL
+  ) +
+  scale_x_continuous(breaks = unique(summary_df$effect_pct)) +
+  scale_y_continuous(limits = c(0, 1)) +
+  labs(
+    x = "Effect size (% of outcome mean)",
+    y = "Power (correct direction)"
+  ) +
+  theme_minimal() +
+  theme(
+    strip.text = element_text(face = "bold"),
+    legend.position = "bottom",
+    panel.grid.minor = element_blank()
+  )
+```
+
+## Type I error
+
+Under the null ($\tau = 0$), the rejection rate estimates the Type I error rate and should be approximately 0.05 for a well-calibrated test.
+
+```{r type1-table}
+summary_df %>%
+  filter(effect_magnitude == 0) %>%
+  select(model_name, n_units, rejection_rate) %>%
+  tidyr::pivot_wider(names_from = n_units, values_from = rejection_rate,
+                     names_prefix = "N=") %>%
+  knitr::kable(digits = 3, caption = "Type I error rate by model and N treated")
+```
+
+## Discussion
+
+Several patterns typically emerge from these comparisons, though the specific results depend on the data and simulation parameters:
+
+- **TWFE** tends to have high power when the number of treated units is moderate to large, but its Type I error can be inflated when treatment timing is staggered and heterogeneous effects are present. In simple settings like this one (with homogeneous, instantaneous effects), TWFE is competitive.
+
+- **AR** models trade some power for robustness to pre-treatment trends by conditioning on lagged outcomes. They can be underpowered when the lagged outcome absorbs much of the variation that would otherwise identify the treatment effect.
+
+- **ASCM** constructs a synthetic control for each treated unit. It is well-suited to settings with few treated units where pre-treatment fit is important, but its power can be lower than regression-based methods when the number of treated units is large, because inference is based on permutation-like reasoning.
+
+- **CSA** is designed for staggered adoption and provides heterogeneity-robust estimates. Its power depends on the number of distinct treatment cohorts and the pre-treatment comparison periods available.
+
+When choosing among methods, researchers should weigh both power and the validity of each method's identifying assumptions. A method with high power but inflated Type I error will produce misleading results. The power curves above can help researchers determine the minimum detectable effect size for each method under their study's design parameters, which informs decisions about sample size, data granularity, and analytic strategy.
+
+# Conclusion
+
+optic makes it possible to compute power for a range of modern policy evaluation methods using a common simulation-based workflow. This can help researchers compare analytic approaches, assess tradeoffs between different approaches, and plan studies that are better matched to their substantive and methodological goals. Please send comments or questions to: optic@rand.org.


### PR DESCRIPTION
## Summary

- New vignette (`power_analysis.Rmd`) demonstrating simulation-based power analysis for TWFE, AR, ASCM, and CSA estimators using the `overdoses` dataset.
- Adds `augsynth` and `ggplot2` to `Suggests` in DESCRIPTION.

-----