### PR TITLE
Validate NA inputs to optic_simulation()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.5
+Version: 1.2.6
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # optic (development version)
 
+## Bug fixes
+
+* `optic_simulation()` now stops early with an informative message when the input data contains NAs in any required column: `unit_var`, `time_var`, the outcome (formula LHS) of any model, or any covariate (formula RHS minus treatment-construct terms) referenced by any model. Treatment columns are excluded because they are simulated by optic. This replaces a class of cryptic downstream errors (e.g. autoeffect's "spec_strategy out of sync" message) with a single upfront error that names the offending columns.
+
 # [optic 1.2.5](https://github.com/RANDCorporation/optic/releases/tag/v1.2.5)
 
 ## New features

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -46,8 +46,6 @@
 #' # Load data for simulation and set up a hypothetical policy effect: 
 #'
 #' data(overdoses)
-#' # Drop the Dakotas: crude.rate has NAs there in early years, which
-#' # optic_simulation() rejects.
 #' overdoses <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
 #' eff <- 0.1*mean(overdoses$crude.rate, na.rm = TRUE)
 #'

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -262,10 +262,6 @@ optic_simulation <- function(x, models, iters,
     params$bias_type <- bias_type
   }
   
-  # Validate that input data has no NAs in columns optic must use across all
-  # models: unit_var, time_var, each model's outcome, and each model's
-  # covariates (formula RHS minus treatment-construct terms). Treatment
-  # columns are simulated by optic and are intentionally excluded.
   .validate_optic_input_nas(x, models, unit_var, time_var)
 
   # Compute prior_control variables:

--- a/R/optic-simulation-helper.R
+++ b/R/optic-simulation-helper.R
@@ -46,18 +46,21 @@
 #' # Load data for simulation and set up a hypothetical policy effect: 
 #'
 #' data(overdoses)
+#' # Drop the Dakotas: crude.rate has NAs there in early years, which
+#' # optic_simulation() rejects.
+#' overdoses <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
 #' eff <- 0.1*mean(overdoses$crude.rate, na.rm = TRUE)
-#' 
+#'
 #' # Set up a simple linear model
 #' form <- formula(crude.rate ~ state + year + population + treatment_level)
-#' mod <- optic_model(name = 'lin', 
-#'                    type = 'reg', 
-#'                    call = 'lm', 
-#'                    formula = form, 
+#' mod <- optic_model(name = 'lin',
+#'                    type = 'reg',
+#'                    call = 'lm',
+#'                    formula = form,
 #'                    se_adjust = 'none')
-#' 
+#'
 #' # Create simulation object, with desired parameters for simulations:
-#' sim <- optic_simulation(x = overdoses, 
+#' sim <- optic_simulation(x = overdoses,
 #'                         models = list(mod), 
 #'                         method = 'no_confounding', 
 #'                         unit_var = 'state', 
@@ -259,9 +262,15 @@ optic_simulation <- function(x, models, iters,
     params$bias_type <- bias_type
   }
   
+  # Validate that input data has no NAs in columns optic must use across all
+  # models: unit_var, time_var, each model's outcome, and each model's
+  # covariates (formula RHS minus treatment-construct terms). Treatment
+  # columns are simulated by optic and are intentionally excluded.
+  .validate_optic_input_nas(x, models, unit_var, time_var)
+
   # Compute prior_control variables:
   first_model_outcome <- get_model_outcome(models[[1]])
-  
+
   x <- compute_prior_controls(data = x,
                               unit_var = params$unit_var,
                               time_var = params$time_var,

--- a/R/validate-input-nas.R
+++ b/R/validate-input-nas.R
@@ -1,0 +1,111 @@
+#------------------------------------------------------------------------------#
+# OPTIC R Package Code Repository
+# Copyright (C) 2023 by The RAND Corporation
+# See README.md for information on usage and licensing
+#------------------------------------------------------------------------------#
+
+#' Validate that input data has no NAs in columns optic must use
+#'
+#' Checks that the union of `unit_var`, `time_var`, each model's outcome
+#' (formula LHS), and each model's covariates (formula RHS minus
+#' treatment-construct terms) is NA-free. Treatment columns are simulated
+#' by optic and are excluded from this check. Stops with an informative
+#' message listing each offending column, its NA count, and a few example
+#' (unit, time) pairs when the offending column is not the unit or time
+#' variable itself.
+#'
+#' @param data Empirical data passed to `optic_simulation()`.
+#' @param models List of `optic_model` objects.
+#' @param unit_var Character. Unit identifier column name.
+#' @param time_var Character. Time variable column name.
+#' @return TRUE invisibly if all columns are NA-free; otherwise stops with
+#'   an informative error.
+#' @keywords internal
+#' @noRd
+.validate_optic_input_nas <- function(data, models, unit_var, time_var) {
+  treatment_terms <- c("treatment_level", "treatment_change", "treatment",
+                       "treatment1_level", "treatment2_level",
+                       "treatment1_change", "treatment2_change",
+                       "trt_ind")
+
+  required_cols <- character(0)
+  required_cols <- c(required_cols, unit_var, time_var)
+  for (m in models) {
+    outcome <- tryCatch(get_model_outcome(m), error = function(e) NULL)
+    if (!is.null(outcome)) {
+      required_cols <- c(required_cols, outcome)
+    }
+    fml <- m[["model_formula"]]
+    if (inherits(fml, "formula")) {
+      rhs <- model_terms(fml)$rhs
+      rhs <- rhs[!rhs %in% treatment_terms]
+      required_cols <- c(required_cols, rhs)
+    }
+  }
+  required_cols <- unique(required_cols)
+  required_cols <- required_cols[required_cols %in% colnames(data)]
+
+  if (length(required_cols) == 0) return(invisible(TRUE))
+
+  na_counts <- vapply(required_cols,
+                      function(col) sum(is.na(data[[col]])),
+                      integer(1))
+  offenders <- required_cols[na_counts > 0]
+  if (length(offenders) == 0) return(invisible(TRUE))
+
+  stop(.format_optic_input_na_error(
+    data, offenders, na_counts[offenders],
+    unit_var = unit_var, time_var = time_var
+  ), call. = FALSE)
+}
+
+#' Format an informative NA-input error message
+#'
+#' @keywords internal
+#' @noRd
+.format_optic_input_na_error <- function(data, offenders, counts,
+                                         unit_var, time_var,
+                                         max_examples = 3L) {
+  lines <- c(
+    "Input data passed to optic_simulation() contains NAs in required",
+    "column(s). optic uses these columns directly to simulate treatment",
+    "assignment, compute prior controls, and fit the supplied models.",
+    "Treatment columns are simulated by optic and are not checked here.",
+    "",
+    "Columns with NAs:"
+  )
+  for (col in offenders) {
+    n_na <- counts[[col]]
+    examples <- character(0)
+    if (col != unit_var && col != time_var &&
+        unit_var %in% colnames(data) && time_var %in% colnames(data)) {
+      bad_idx <- which(is.na(data[[col]]))
+      if (length(bad_idx) > 0) {
+        idx <- utils::head(bad_idx, max_examples)
+        examples <- vapply(
+          idx,
+          function(i) sprintf("%s=%s, %s=%s",
+                              unit_var, format(data[[unit_var]][i]),
+                              time_var, format(data[[time_var]][i])),
+          character(1)
+        )
+      }
+    }
+    msg <- sprintf("  - %s: %d NA values", col, n_na)
+    if (length(examples) > 0) {
+      msg <- paste0(
+        msg, " (e.g., ",
+        paste(examples, collapse = "; "),
+        if (n_na > length(examples)) ", ..." else "",
+        ")"
+      )
+    }
+    lines <- c(lines, msg)
+  }
+  lines <- c(
+    lines,
+    "",
+    "Remove or impute NA rows before passing the data to optic_simulation()."
+  )
+  paste(lines, collapse = "\n")
+}

--- a/R/validate-input-nas.R
+++ b/R/validate-input-nas.R
@@ -1,15 +1,7 @@
-#' Stop if input data has NAs in any column optic must use
-#'
-#' Validates the union of `unit_var`, `time_var`, each model's outcome,
-#' and each model's covariates (formula RHS minus treatment-construct
-#' terms). Treatment columns are simulated by optic and excluded.
-#'
-#' @keywords internal
-#' @noRd
+# Stop if input data has NAs in columns optic uses across all models.
 .validate_optic_input_nas <- function(data, models, unit_var, time_var) {
-  trt <- c("treatment_level", "treatment_change", "treatment",
-           "treatment1_level", "treatment2_level",
-           "treatment1_change", "treatment2_change", "trt_ind")
+  trt <- c("treatment_level", "treatment_change", "treatment", "trt_ind",
+           "treatment1_level", "treatment2_level", "treatment1_change", "treatment2_change")
   cols <- c(unit_var, time_var)
   for (m in models) {
     cols <- c(cols, tryCatch(get_model_outcome(m), error = function(e) NULL))
@@ -18,28 +10,21 @@
       cols <- c(cols, rhs[!rhs %in% trt])
     }
   }
-  cols <- unique(cols); cols <- cols[cols %in% colnames(data)]
-  if (!length(cols)) return(invisible(TRUE))
+  cols <- intersect(unique(cols), colnames(data))
   n <- vapply(cols, function(c) sum(is.na(data[[c]])), integer(1))
-  bad <- cols[n > 0]
-  if (!length(bad)) return(invisible(TRUE))
-
+  bad <- cols[n > 0]; if (!length(bad)) return(invisible(TRUE))
+  has_keys <- all(c(unit_var, time_var) %in% colnames(data))
   msgs <- vapply(bad, function(col) {
-    head_msg <- sprintf("  - %s: %d NA values", col, n[[col]])
-    if (col %in% c(unit_var, time_var) ||
-        !all(c(unit_var, time_var) %in% colnames(data))) return(head_msg)
+    h <- sprintf("  - %s: %d NA values", col, n[[col]])
+    if (!has_keys || col %in% c(unit_var, time_var)) return(h)
     idx <- utils::head(which(is.na(data[[col]])), 3L)
-    ex <- sprintf("%s=%s, %s=%s",
-                  unit_var, format(data[[unit_var]][idx]),
+    ex <- sprintf("%s=%s, %s=%s", unit_var, format(data[[unit_var]][idx]),
                   time_var, format(data[[time_var]][idx]))
-    more <- if (n[[col]] > length(idx)) ", ..." else ""
-    paste0(head_msg, " (e.g., ", paste(ex, collapse = "; "), more, ")")
+    paste0(h, " (e.g., ", paste(ex, collapse = "; "),
+           if (n[[col]] > length(idx)) ", ..." else "", ")")
   }, character(1))
-
-  stop(paste(c(
-    "Input data passed to optic_simulation() contains NAs in required column(s).",
-    "Treatment columns are simulated by optic and are not checked here.",
-    "", "Columns with NAs:", msgs, "",
-    "Remove or impute NA rows before passing the data to optic_simulation()."
-  ), collapse = "\n"), call. = FALSE)
+  stop(paste(c("optic_simulation() requires NA-free unit, time, outcome, and covariate columns.",
+               "Treatment columns are simulated by optic and are not checked.", "",
+               "Columns with NAs:", msgs, "", "Remove or impute NA rows."),
+             collapse = "\n"), call. = FALSE)
 }

--- a/R/validate-input-nas.R
+++ b/R/validate-input-nas.R
@@ -1,9 +1,3 @@
-#------------------------------------------------------------------------------#
-# OPTIC R Package Code Repository
-# Copyright (C) 2023 by The RAND Corporation
-# See README.md for information on usage and licensing
-#------------------------------------------------------------------------------#
-
 #' Stop if input data has NAs in any column optic must use
 #'
 #' Validates the union of `unit_var`, `time_var`, each model's outcome,
@@ -13,53 +7,39 @@
 #' @keywords internal
 #' @noRd
 .validate_optic_input_nas <- function(data, models, unit_var, time_var) {
-  trt_terms <- c("treatment_level", "treatment_change", "treatment",
-                 "treatment1_level", "treatment2_level",
-                 "treatment1_change", "treatment2_change", "trt_ind")
-
+  trt <- c("treatment_level", "treatment_change", "treatment",
+           "treatment1_level", "treatment2_level",
+           "treatment1_change", "treatment2_change", "trt_ind")
   cols <- c(unit_var, time_var)
   for (m in models) {
     cols <- c(cols, tryCatch(get_model_outcome(m), error = function(e) NULL))
-    fml <- m[["model_formula"]]
-    if (inherits(fml, "formula")) {
-      rhs <- model_terms(fml)$rhs
-      cols <- c(cols, rhs[!rhs %in% trt_terms])
+    if (inherits(m[["model_formula"]], "formula")) {
+      rhs <- model_terms(m[["model_formula"]])$rhs
+      cols <- c(cols, rhs[!rhs %in% trt])
     }
   }
-  cols <- unique(cols)
-  cols <- cols[cols %in% colnames(data)]
-  if (length(cols) == 0) return(invisible(TRUE))
+  cols <- unique(cols); cols <- cols[cols %in% colnames(data)]
+  if (!length(cols)) return(invisible(TRUE))
+  n <- vapply(cols, function(c) sum(is.na(data[[c]])), integer(1))
+  bad <- cols[n > 0]
+  if (!length(bad)) return(invisible(TRUE))
 
-  na_counts <- vapply(cols, function(c) sum(is.na(data[[c]])), integer(1))
-  offenders <- cols[na_counts > 0]
-  if (length(offenders) == 0) return(invisible(TRUE))
+  msgs <- vapply(bad, function(col) {
+    head_msg <- sprintf("  - %s: %d NA values", col, n[[col]])
+    if (col %in% c(unit_var, time_var) ||
+        !all(c(unit_var, time_var) %in% colnames(data))) return(head_msg)
+    idx <- utils::head(which(is.na(data[[col]])), 3L)
+    ex <- sprintf("%s=%s, %s=%s",
+                  unit_var, format(data[[unit_var]][idx]),
+                  time_var, format(data[[time_var]][idx]))
+    more <- if (n[[col]] > length(idx)) ", ..." else ""
+    paste0(head_msg, " (e.g., ", paste(ex, collapse = "; "), more, ")")
+  }, character(1))
 
-  stop(.format_optic_input_na_error(data, offenders, na_counts[offenders],
-                                    unit_var, time_var), call. = FALSE)
-}
-
-.format_optic_input_na_error <- function(data, offenders, counts,
-                                         unit_var, time_var, max_ex = 3L) {
-  lines <- c(
+  stop(paste(c(
     "Input data passed to optic_simulation() contains NAs in required column(s).",
     "Treatment columns are simulated by optic and are not checked here.",
-    "",
-    "Columns with NAs:"
-  )
-  has_keys <- unit_var %in% colnames(data) && time_var %in% colnames(data)
-  for (col in offenders) {
-    msg <- sprintf("  - %s: %d NA values", col, counts[[col]])
-    if (has_keys && !col %in% c(unit_var, time_var)) {
-      idx <- utils::head(which(is.na(data[[col]])), max_ex)
-      ex <- sprintf("%s=%s, %s=%s",
-                    unit_var, format(data[[unit_var]][idx]),
-                    time_var, format(data[[time_var]][idx]))
-      more <- if (counts[[col]] > length(idx)) ", ..." else ""
-      msg <- paste0(msg, " (e.g., ", paste(ex, collapse = "; "), more, ")")
-    }
-    lines <- c(lines, msg)
-  }
-  paste(c(lines, "",
-          "Remove or impute NA rows before passing the data to optic_simulation()."),
-        collapse = "\n")
+    "", "Columns with NAs:", msgs, "",
+    "Remove or impute NA rows before passing the data to optic_simulation()."
+  ), collapse = "\n"), call. = FALSE)
 }

--- a/R/validate-input-nas.R
+++ b/R/validate-input-nas.R
@@ -4,108 +4,62 @@
 # See README.md for information on usage and licensing
 #------------------------------------------------------------------------------#
 
-#' Validate that input data has no NAs in columns optic must use
+#' Stop if input data has NAs in any column optic must use
 #'
-#' Checks that the union of `unit_var`, `time_var`, each model's outcome
-#' (formula LHS), and each model's covariates (formula RHS minus
-#' treatment-construct terms) is NA-free. Treatment columns are simulated
-#' by optic and are excluded from this check. Stops with an informative
-#' message listing each offending column, its NA count, and a few example
-#' (unit, time) pairs when the offending column is not the unit or time
-#' variable itself.
+#' Validates the union of `unit_var`, `time_var`, each model's outcome,
+#' and each model's covariates (formula RHS minus treatment-construct
+#' terms). Treatment columns are simulated by optic and excluded.
 #'
-#' @param data Empirical data passed to `optic_simulation()`.
-#' @param models List of `optic_model` objects.
-#' @param unit_var Character. Unit identifier column name.
-#' @param time_var Character. Time variable column name.
-#' @return TRUE invisibly if all columns are NA-free; otherwise stops with
-#'   an informative error.
 #' @keywords internal
 #' @noRd
 .validate_optic_input_nas <- function(data, models, unit_var, time_var) {
-  treatment_terms <- c("treatment_level", "treatment_change", "treatment",
-                       "treatment1_level", "treatment2_level",
-                       "treatment1_change", "treatment2_change",
-                       "trt_ind")
+  trt_terms <- c("treatment_level", "treatment_change", "treatment",
+                 "treatment1_level", "treatment2_level",
+                 "treatment1_change", "treatment2_change", "trt_ind")
 
-  required_cols <- character(0)
-  required_cols <- c(required_cols, unit_var, time_var)
+  cols <- c(unit_var, time_var)
   for (m in models) {
-    outcome <- tryCatch(get_model_outcome(m), error = function(e) NULL)
-    if (!is.null(outcome)) {
-      required_cols <- c(required_cols, outcome)
-    }
+    cols <- c(cols, tryCatch(get_model_outcome(m), error = function(e) NULL))
     fml <- m[["model_formula"]]
     if (inherits(fml, "formula")) {
       rhs <- model_terms(fml)$rhs
-      rhs <- rhs[!rhs %in% treatment_terms]
-      required_cols <- c(required_cols, rhs)
+      cols <- c(cols, rhs[!rhs %in% trt_terms])
     }
   }
-  required_cols <- unique(required_cols)
-  required_cols <- required_cols[required_cols %in% colnames(data)]
+  cols <- unique(cols)
+  cols <- cols[cols %in% colnames(data)]
+  if (length(cols) == 0) return(invisible(TRUE))
 
-  if (length(required_cols) == 0) return(invisible(TRUE))
-
-  na_counts <- vapply(required_cols,
-                      function(col) sum(is.na(data[[col]])),
-                      integer(1))
-  offenders <- required_cols[na_counts > 0]
+  na_counts <- vapply(cols, function(c) sum(is.na(data[[c]])), integer(1))
+  offenders <- cols[na_counts > 0]
   if (length(offenders) == 0) return(invisible(TRUE))
 
-  stop(.format_optic_input_na_error(
-    data, offenders, na_counts[offenders],
-    unit_var = unit_var, time_var = time_var
-  ), call. = FALSE)
+  stop(.format_optic_input_na_error(data, offenders, na_counts[offenders],
+                                    unit_var, time_var), call. = FALSE)
 }
 
-#' Format an informative NA-input error message
-#'
-#' @keywords internal
-#' @noRd
 .format_optic_input_na_error <- function(data, offenders, counts,
-                                         unit_var, time_var,
-                                         max_examples = 3L) {
+                                         unit_var, time_var, max_ex = 3L) {
   lines <- c(
-    "Input data passed to optic_simulation() contains NAs in required",
-    "column(s). optic uses these columns directly to simulate treatment",
-    "assignment, compute prior controls, and fit the supplied models.",
+    "Input data passed to optic_simulation() contains NAs in required column(s).",
     "Treatment columns are simulated by optic and are not checked here.",
     "",
     "Columns with NAs:"
   )
+  has_keys <- unit_var %in% colnames(data) && time_var %in% colnames(data)
   for (col in offenders) {
-    n_na <- counts[[col]]
-    examples <- character(0)
-    if (col != unit_var && col != time_var &&
-        unit_var %in% colnames(data) && time_var %in% colnames(data)) {
-      bad_idx <- which(is.na(data[[col]]))
-      if (length(bad_idx) > 0) {
-        idx <- utils::head(bad_idx, max_examples)
-        examples <- vapply(
-          idx,
-          function(i) sprintf("%s=%s, %s=%s",
-                              unit_var, format(data[[unit_var]][i]),
-                              time_var, format(data[[time_var]][i])),
-          character(1)
-        )
-      }
-    }
-    msg <- sprintf("  - %s: %d NA values", col, n_na)
-    if (length(examples) > 0) {
-      msg <- paste0(
-        msg, " (e.g., ",
-        paste(examples, collapse = "; "),
-        if (n_na > length(examples)) ", ..." else "",
-        ")"
-      )
+    msg <- sprintf("  - %s: %d NA values", col, counts[[col]])
+    if (has_keys && !col %in% c(unit_var, time_var)) {
+      idx <- utils::head(which(is.na(data[[col]])), max_ex)
+      ex <- sprintf("%s=%s, %s=%s",
+                    unit_var, format(data[[unit_var]][idx]),
+                    time_var, format(data[[time_var]][idx]))
+      more <- if (counts[[col]] > length(idx)) ", ..." else ""
+      msg <- paste0(msg, " (e.g., ", paste(ex, collapse = "; "), more, ")")
     }
     lines <- c(lines, msg)
   }
-  lines <- c(
-    lines,
-    "",
-    "Remove or impute NA rows before passing the data to optic_simulation()."
-  )
-  paste(lines, collapse = "\n")
+  paste(c(lines, "",
+          "Remove or impute NA rows before passing the data to optic_simulation()."),
+        collapse = "\n")
 }

--- a/man/optic_simulation.Rd
+++ b/man/optic_simulation.Rd
@@ -104,18 +104,21 @@ The resulting configuration object is used to pass simulation scenarios to the '
 # Load data for simulation and set up a hypothetical policy effect: 
 
 data(overdoses)
+# Drop the Dakotas: crude.rate has NAs there in early years, which
+# optic_simulation() rejects.
+overdoses <- overdoses[!overdoses$state \%in\% c("North Dakota", "South Dakota"), ]
 eff <- 0.1*mean(overdoses$crude.rate, na.rm = TRUE)
 
 # Set up a simple linear model
 form <- formula(crude.rate ~ state + year + population + treatment_level)
-mod <- optic_model(name = 'lin', 
-                   type = 'reg', 
-                   call = 'lm', 
-                   formula = form, 
+mod <- optic_model(name = 'lin',
+                   type = 'reg',
+                   call = 'lm',
+                   formula = form,
                    se_adjust = 'none')
 
 # Create simulation object, with desired parameters for simulations:
-sim <- optic_simulation(x = overdoses, 
+sim <- optic_simulation(x = overdoses,
                         models = list(mod), 
                         method = 'no_confounding', 
                         unit_var = 'state', 

--- a/man/optic_simulation.Rd
+++ b/man/optic_simulation.Rd
@@ -104,8 +104,6 @@ The resulting configuration object is used to pass simulation scenarios to the '
 # Load data for simulation and set up a hypothetical policy effect: 
 
 data(overdoses)
-# Drop the Dakotas: crude.rate has NAs there in early years, which
-# optic_simulation() rejects.
 overdoses <- overdoses[!overdoses$state \%in\% c("North Dakota", "South Dakota"), ]
 eff <- 0.1*mean(overdoses$crude.rate, na.rm = TRUE)
 

--- a/tests/testthat/test-concurrent.R
+++ b/tests/testthat/test-concurrent.R
@@ -7,9 +7,7 @@
 # Testing an example of the concurrent method.
 
 data(overdoses)
-# Drop the Dakotas: their crude.rate column has NAs in early years, which
-# optic_simulation()'s input validation now rejects. Filtering whole states
-# rather than NA rows keeps the panel balanced for downstream sampling.
+# Dakotas have NA crude.rate; optic_simulation() now rejects NA inputs.
 x <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
 
 # we will define two scenarios for different effect magnitudes for

--- a/tests/testthat/test-concurrent.R
+++ b/tests/testthat/test-concurrent.R
@@ -7,7 +7,10 @@
 # Testing an example of the concurrent method.
 
 data(overdoses)
-x <- overdoses
+# Drop the Dakotas: their crude.rate column has NAs in early years, which
+# optic_simulation()'s input validation now rejects. Filtering whole states
+# rather than NA rows keeps the panel balanced for downstream sampling.
+x <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
 
 # we will define two scenarios for different effect magnitudes for
 # the policies using 5, 10, and 15 percent changes in the outcome
@@ -48,7 +51,7 @@ test_that("can create optic_model", {
 # Test Concurrent Methods -------------------------------------------------
 
 concurrent_optic_sim <- optic_simulation(
-  x=overdoses,
+  x=x,
   models=list(model_1, model_2),
   iters=10,
   method="concurrent",

--- a/tests/testthat/test-input-na-validation.R
+++ b/tests/testthat/test-input-na-validation.R
@@ -1,136 +1,61 @@
-#------------------------------------------------------------------------------#
 # Tests for NA-input validation in optic_simulation()
-#------------------------------------------------------------------------------#
 
-make_clean_optic_panel <- function(n_units = 6, years = 2010:2018, seed = 1) {
+clean_panel <- function(n = 6, years = 2010:2018, seed = 1) {
   set.seed(seed)
-  dat <- expand.grid(
-    state = sprintf("State%02d", seq_len(n_units)),
-    year = years,
-    stringsAsFactors = FALSE
-  )
-  dat <- dat[order(dat$state, dat$year), ]
-  dat$crude.rate <- stats::rnorm(nrow(dat), mean = 12, sd = 3)
-  dat$population <- 1000
-  dat$unemploymentrate <- stats::rnorm(nrow(dat), mean = 5, sd = 1)
-  dat
+  d <- expand.grid(state = sprintf("S%02d", seq_len(n)),
+                   year = years, stringsAsFactors = FALSE)
+  d <- d[order(d$state, d$year), ]
+  d$crude.rate <- stats::rnorm(nrow(d), 12, 3)
+  d$population <- 1000
+  d$unemploymentrate <- stats::rnorm(nrow(d), 5, 1)
+  d
 }
 
-reg_model <- function(formula = crude.rate ~ treatment_level + unemploymentrate) {
-  optic_model(
-    name = "test_model",
-    type = "reg",
-    call = "lm",
-    formula = formula,
-    se_adjust = "none"
-  )
+reg_mod <- function(fml = crude.rate ~ treatment_level + unemploymentrate,
+                    name = "m") {
+  optic_model(name = name, type = "reg", call = "lm",
+              formula = fml, se_adjust = "none")
 }
 
-base_sim_args <- function(x, models) {
-  list(
-    x = x,
-    models = if (is.list(models) && !inherits(models[[1]], "list")) models else models,
-    iters = 2,
-    method = "no_confounding",
-    unit_var = "state",
-    treat_var = "state",
-    time_var = "year",
-    effect_magnitude = list(0),
-    n_units = 2,
-    effect_direction = "pos",
-    policy_speed = "instant",
-    n_implementation_periods = 1,
-    verbose = FALSE
-  )
+run_sim <- function(x, models) {
+  optic_simulation(x = x, models = models, iters = 2,
+                   method = "no_confounding", unit_var = "state",
+                   treat_var = "state", time_var = "year",
+                   effect_magnitude = list(0), n_units = 2,
+                   effect_direction = "pos", policy_speed = "instant",
+                   n_implementation_periods = 1, verbose = FALSE)
 }
 
-test_that("optic_simulation errors when outcome has NAs", {
-  dat <- make_clean_optic_panel()
-  dat$crude.rate[dat$year == 2014] <- NA_real_
-
-  args <- base_sim_args(dat, list(reg_model()))
-  expect_error(
-    do.call(optic_simulation, args),
-    "Input data passed to optic_simulation\\(\\) contains NAs"
-  )
-})
-
-test_that("optic_simulation NA error names the offending column", {
-  dat <- make_clean_optic_panel()
-  dat$crude.rate[dat$year == 2014] <- NA_real_
-
-  args <- base_sim_args(dat, list(reg_model()))
-  err <- tryCatch(do.call(optic_simulation, args),
+test_that("flags NA in outcome and names column + example", {
+  d <- clean_panel(); d$crude.rate[d$year == 2014] <- NA_real_
+  err <- tryCatch(run_sim(d, list(reg_mod())),
                   error = function(e) conditionMessage(e))
-
+  expect_match(err, "Input data passed to optic_simulation\\(\\) contains NAs")
   expect_match(err, "crude.rate:.*6 NA values")
-  expect_match(err, "state=State", fixed = FALSE)
+  expect_match(err, "state=S")
   expect_match(err, "year=2014", fixed = TRUE)
 })
 
-test_that("optic_simulation errors when unit_var has NAs", {
-  dat <- make_clean_optic_panel()
-  dat$state[3] <- NA_character_
-
-  args <- base_sim_args(dat, list(reg_model()))
-  expect_error(
-    do.call(optic_simulation, args),
-    "state"
-  )
+test_that("flags NA in unit_var, time_var, and covariates", {
+  d1 <- clean_panel(); d1$state[3] <- NA_character_
+  expect_error(run_sim(d1, list(reg_mod())), "state")
+  d2 <- clean_panel(); d2$year[5] <- NA_integer_
+  expect_error(run_sim(d2, list(reg_mod())), "year")
+  d3 <- clean_panel(); d3$unemploymentrate[c(2, 4, 6)] <- NA_real_
+  expect_error(run_sim(d3, list(reg_mod())), "unemploymentrate")
 })
 
-test_that("optic_simulation errors when time_var has NAs", {
-  dat <- make_clean_optic_panel()
-  dat$year[5] <- NA_integer_
-
-  args <- base_sim_args(dat, list(reg_model()))
-  expect_error(
-    do.call(optic_simulation, args),
-    "year"
-  )
+test_that("ignores unused columns and accepts a clean panel", {
+  d <- clean_panel(); d$unused <- NA_real_
+  expect_s3_class(run_sim(d, list(reg_mod())), "OpticSim")
+  expect_s3_class(run_sim(clean_panel(), list(reg_mod())), "OpticSim")
 })
 
-test_that("optic_simulation errors when a covariate has NAs", {
-  dat <- make_clean_optic_panel()
-  dat$unemploymentrate[c(2, 4, 6)] <- NA_real_
-
-  args <- base_sim_args(dat, list(reg_model()))
-  expect_error(
-    do.call(optic_simulation, args),
-    "unemploymentrate"
-  )
-})
-
-test_that("optic_simulation does not flag unused columns", {
-  dat <- make_clean_optic_panel()
-  dat$irrelevant_col <- NA_real_
-
-  args <- base_sim_args(
-    dat,
-    list(reg_model(formula = crude.rate ~ treatment_level + unemploymentrate))
-  )
-
-  expect_s3_class(do.call(optic_simulation, args), "OpticSim")
-})
-
-test_that("optic_simulation accepts a clean panel", {
-  dat <- make_clean_optic_panel()
-
-  args <- base_sim_args(dat, list(reg_model()))
-  expect_s3_class(do.call(optic_simulation, args), "OpticSim")
-})
-
-test_that("optic_simulation reports columns from the union across models", {
-  dat <- make_clean_optic_panel()
-  dat$population[1:5] <- NA_real_
-
-  m1 <- reg_model(formula = crude.rate ~ treatment_level + unemploymentrate)
-  m2 <- reg_model(formula = crude.rate ~ treatment_level + population)
-  m2$name <- "test_model2"
-
-  args <- base_sim_args(dat, list(m1, m2))
-  err <- tryCatch(do.call(optic_simulation, args),
+test_that("checks the union of columns across models", {
+  d <- clean_panel(); d$population[1:5] <- NA_real_
+  m1 <- reg_mod(name = "m1")
+  m2 <- reg_mod(crude.rate ~ treatment_level + population, name = "m2")
+  err <- tryCatch(run_sim(d, list(m1, m2)),
                   error = function(e) conditionMessage(e))
-
   expect_match(err, "population")
 })

--- a/tests/testthat/test-input-na-validation.R
+++ b/tests/testthat/test-input-na-validation.R
@@ -1,61 +1,36 @@
-# Tests for NA-input validation in optic_simulation()
+test_that("optic_simulation NA-input validation", {
+  set.seed(1)
+  base <- expand.grid(state = sprintf("S%02d", 1:6), year = 2010:2018,
+                      stringsAsFactors = FALSE)
+  base$crude.rate <- stats::rnorm(nrow(base), 12, 3)
+  base$population <- 1000
+  base$unemploymentrate <- stats::rnorm(nrow(base), 5, 1)
+  mk <- function(fml = crude.rate ~ treatment_level + unemploymentrate, name = "m")
+    optic_model(name = name, type = "reg", call = "lm", formula = fml, se_adjust = "none")
+  run <- function(x, m) optic_simulation(x = x, models = m, iters = 2,
+    method = "no_confounding", unit_var = "state", treat_var = "state",
+    time_var = "year", effect_magnitude = list(0), n_units = 2,
+    effect_direction = "pos", policy_speed = "instant",
+    n_implementation_periods = 1, verbose = FALSE)
 
-clean_panel <- function(n = 6, years = 2010:2018, seed = 1) {
-  set.seed(seed)
-  d <- expand.grid(state = sprintf("S%02d", seq_len(n)),
-                   year = years, stringsAsFactors = FALSE)
-  d <- d[order(d$state, d$year), ]
-  d$crude.rate <- stats::rnorm(nrow(d), 12, 3)
-  d$population <- 1000
-  d$unemploymentrate <- stats::rnorm(nrow(d), 5, 1)
-  d
-}
-
-reg_mod <- function(fml = crude.rate ~ treatment_level + unemploymentrate,
-                    name = "m") {
-  optic_model(name = name, type = "reg", call = "lm",
-              formula = fml, se_adjust = "none")
-}
-
-run_sim <- function(x, models) {
-  optic_simulation(x = x, models = models, iters = 2,
-                   method = "no_confounding", unit_var = "state",
-                   treat_var = "state", time_var = "year",
-                   effect_magnitude = list(0), n_units = 2,
-                   effect_direction = "pos", policy_speed = "instant",
-                   n_implementation_periods = 1, verbose = FALSE)
-}
-
-test_that("flags NA in outcome and names column + example", {
-  d <- clean_panel(); d$crude.rate[d$year == 2014] <- NA_real_
-  err <- tryCatch(run_sim(d, list(reg_mod())),
-                  error = function(e) conditionMessage(e))
-  expect_match(err, "Input data passed to optic_simulation\\(\\) contains NAs")
+  d <- base; d$crude.rate[d$year == 2014] <- NA_real_
+  err <- tryCatch(run(d, list(mk())), error = conditionMessage)
+  expect_match(err, "optic_simulation\\(\\) requires NA-free")
   expect_match(err, "crude.rate:.*6 NA values")
-  expect_match(err, "state=S")
   expect_match(err, "year=2014", fixed = TRUE)
-})
 
-test_that("flags NA in unit_var, time_var, and covariates", {
-  d1 <- clean_panel(); d1$state[3] <- NA_character_
-  expect_error(run_sim(d1, list(reg_mod())), "state")
-  d2 <- clean_panel(); d2$year[5] <- NA_integer_
-  expect_error(run_sim(d2, list(reg_mod())), "year")
-  d3 <- clean_panel(); d3$unemploymentrate[c(2, 4, 6)] <- NA_real_
-  expect_error(run_sim(d3, list(reg_mod())), "unemploymentrate")
-})
+  for (col in c("state", "year", "unemploymentrate")) {
+    d <- base; d[[col]][3] <- NA
+    expect_error(run(d, list(mk())), col)
+  }
 
-test_that("ignores unused columns and accepts a clean panel", {
-  d <- clean_panel(); d$unused <- NA_real_
-  expect_s3_class(run_sim(d, list(reg_mod())), "OpticSim")
-  expect_s3_class(run_sim(clean_panel(), list(reg_mod())), "OpticSim")
-})
+  d <- base; d$unused <- NA_real_
+  expect_s3_class(run(d, list(mk())), "OpticSim")
+  expect_s3_class(run(base, list(mk())), "OpticSim")
 
-test_that("checks the union of columns across models", {
-  d <- clean_panel(); d$population[1:5] <- NA_real_
-  m1 <- reg_mod(name = "m1")
-  m2 <- reg_mod(crude.rate ~ treatment_level + population, name = "m2")
-  err <- tryCatch(run_sim(d, list(m1, m2)),
-                  error = function(e) conditionMessage(e))
+  d <- base; d$population[1:5] <- NA_real_
+  err <- tryCatch(run(d, list(mk(name = "m1"),
+                               mk(crude.rate ~ treatment_level + population, "m2"))),
+                  error = conditionMessage)
   expect_match(err, "population")
 })

--- a/tests/testthat/test-input-na-validation.R
+++ b/tests/testthat/test-input-na-validation.R
@@ -1,0 +1,136 @@
+#------------------------------------------------------------------------------#
+# Tests for NA-input validation in optic_simulation()
+#------------------------------------------------------------------------------#
+
+make_clean_optic_panel <- function(n_units = 6, years = 2010:2018, seed = 1) {
+  set.seed(seed)
+  dat <- expand.grid(
+    state = sprintf("State%02d", seq_len(n_units)),
+    year = years,
+    stringsAsFactors = FALSE
+  )
+  dat <- dat[order(dat$state, dat$year), ]
+  dat$crude.rate <- stats::rnorm(nrow(dat), mean = 12, sd = 3)
+  dat$population <- 1000
+  dat$unemploymentrate <- stats::rnorm(nrow(dat), mean = 5, sd = 1)
+  dat
+}
+
+reg_model <- function(formula = crude.rate ~ treatment_level + unemploymentrate) {
+  optic_model(
+    name = "test_model",
+    type = "reg",
+    call = "lm",
+    formula = formula,
+    se_adjust = "none"
+  )
+}
+
+base_sim_args <- function(x, models) {
+  list(
+    x = x,
+    models = if (is.list(models) && !inherits(models[[1]], "list")) models else models,
+    iters = 2,
+    method = "no_confounding",
+    unit_var = "state",
+    treat_var = "state",
+    time_var = "year",
+    effect_magnitude = list(0),
+    n_units = 2,
+    effect_direction = "pos",
+    policy_speed = "instant",
+    n_implementation_periods = 1,
+    verbose = FALSE
+  )
+}
+
+test_that("optic_simulation errors when outcome has NAs", {
+  dat <- make_clean_optic_panel()
+  dat$crude.rate[dat$year == 2014] <- NA_real_
+
+  args <- base_sim_args(dat, list(reg_model()))
+  expect_error(
+    do.call(optic_simulation, args),
+    "Input data passed to optic_simulation\\(\\) contains NAs"
+  )
+})
+
+test_that("optic_simulation NA error names the offending column", {
+  dat <- make_clean_optic_panel()
+  dat$crude.rate[dat$year == 2014] <- NA_real_
+
+  args <- base_sim_args(dat, list(reg_model()))
+  err <- tryCatch(do.call(optic_simulation, args),
+                  error = function(e) conditionMessage(e))
+
+  expect_match(err, "crude.rate:.*6 NA values")
+  expect_match(err, "state=State", fixed = FALSE)
+  expect_match(err, "year=2014", fixed = TRUE)
+})
+
+test_that("optic_simulation errors when unit_var has NAs", {
+  dat <- make_clean_optic_panel()
+  dat$state[3] <- NA_character_
+
+  args <- base_sim_args(dat, list(reg_model()))
+  expect_error(
+    do.call(optic_simulation, args),
+    "state"
+  )
+})
+
+test_that("optic_simulation errors when time_var has NAs", {
+  dat <- make_clean_optic_panel()
+  dat$year[5] <- NA_integer_
+
+  args <- base_sim_args(dat, list(reg_model()))
+  expect_error(
+    do.call(optic_simulation, args),
+    "year"
+  )
+})
+
+test_that("optic_simulation errors when a covariate has NAs", {
+  dat <- make_clean_optic_panel()
+  dat$unemploymentrate[c(2, 4, 6)] <- NA_real_
+
+  args <- base_sim_args(dat, list(reg_model()))
+  expect_error(
+    do.call(optic_simulation, args),
+    "unemploymentrate"
+  )
+})
+
+test_that("optic_simulation does not flag unused columns", {
+  dat <- make_clean_optic_panel()
+  dat$irrelevant_col <- NA_real_
+
+  args <- base_sim_args(
+    dat,
+    list(reg_model(formula = crude.rate ~ treatment_level + unemploymentrate))
+  )
+
+  expect_s3_class(do.call(optic_simulation, args), "OpticSim")
+})
+
+test_that("optic_simulation accepts a clean panel", {
+  dat <- make_clean_optic_panel()
+
+  args <- base_sim_args(dat, list(reg_model()))
+  expect_s3_class(do.call(optic_simulation, args), "OpticSim")
+})
+
+test_that("optic_simulation reports columns from the union across models", {
+  dat <- make_clean_optic_panel()
+  dat$population[1:5] <- NA_real_
+
+  m1 <- reg_model(formula = crude.rate ~ treatment_level + unemploymentrate)
+  m2 <- reg_model(formula = crude.rate ~ treatment_level + population)
+  m2$name <- "test_model2"
+
+  args <- base_sim_args(dat, list(m1, m2))
+  err <- tryCatch(do.call(optic_simulation, args),
+                  error = function(e) conditionMessage(e))
+
+  expect_match(err, "population")
+})

--- a/tests/testthat/test-no_confounding.R
+++ b/tests/testthat/test-no_confounding.R
@@ -22,9 +22,13 @@ fixedeff_linear <- optic_model(
   se_adjust=c("none", "cluster-unit")
 )
 
-# Remove states for consistency:
+# Remove states for consistency. The Dakotas are also dropped because their
+# crude.rate column has NAs in early years, which optic_simulation()'s input
+# validation now rejects. Filtering whole states (rather than NA rows)
+# preserves a balanced panel for the sampler.
 data <- overdoses %>%
-  dplyr::filter(!(state %in% c("Nebraska", "Nevada", "Arkansas", "Mississippi", "Oregon")))
+  dplyr::filter(!(state %in% c("Nebraska", "Nevada", "Arkansas", "Mississippi",
+                               "Oregon", "North Dakota", "South Dakota")))
 
 #------------------------------------------------------------------------------#
 # Test 1: Simple test for R CMD check (CRAN-compatible, fast)

--- a/tests/testthat/test-no_confounding.R
+++ b/tests/testthat/test-no_confounding.R
@@ -22,10 +22,7 @@ fixedeff_linear <- optic_model(
   se_adjust=c("none", "cluster-unit")
 )
 
-# Remove states for consistency. The Dakotas are also dropped because their
-# crude.rate column has NAs in early years, which optic_simulation()'s input
-# validation now rejects. Filtering whole states (rather than NA rows)
-# preserves a balanced panel for the sampler.
+# Remove states for consistency; Dakotas dropped because crude.rate has NAs.
 data <- overdoses %>%
   dplyr::filter(!(state %in% c("Nebraska", "Nevada", "Arkansas", "Mississippi",
                                "Oregon", "North Dakota", "South Dakota")))

--- a/vignettes/intro_optic.Rmd
+++ b/vignettes/intro_optic.Rmd
@@ -115,10 +115,7 @@ the example_data:
 
 data(overdoses)
 
-# Drop the Dakotas because their crude.rate column has NAs in early years.
-# optic_simulation() requires its outcome and covariate columns to be
-# NA-free, and dropping just the NA rows would produce an unbalanced panel
-# that the simulator does not support.
+# Drop the Dakotas: crude.rate has NAs there in early years.
 overdoses <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
 
 # Calculate a hypothetical 5% and 10% changes in mean opioid_death_rate,

--- a/vignettes/intro_optic.Rmd
+++ b/vignettes/intro_optic.Rmd
@@ -115,8 +115,14 @@ the example_data:
 
 data(overdoses)
 
-# Calculate a hypothetical 5% and 10% changes in mean opioid_death_rate, 
-# across states and years. 
+# Drop the Dakotas because their crude.rate column has NAs in early years.
+# optic_simulation() requires its outcome and covariate columns to be
+# NA-free, and dropping just the NA rows would produce an unbalanced panel
+# that the simulator does not support.
+overdoses <- overdoses[!overdoses$state %in% c("North Dakota", "South Dakota"), ]
+
+# Calculate a hypothetical 5% and 10% changes in mean opioid_death_rate,
+# across states and years.
 five_percent_effect <- 0.05*mean(overdoses$crude.rate, na.rm = T)
 ten_percent_effect  <- 0.10*mean(overdoses$crude.rate, na.rm = T)
 
@@ -302,7 +308,7 @@ sim_config <- optic_simulation(
   treat_var                = "state",
   time_var                 = "year",
   effect_magnitude         = scenarios_no_confounding,
-  n_units                  = c(30, 40, 50),
+  n_units                  = c(30, 40, 49),
   effect_direction         = c("neg"),
   policy_speed             = c("instant"),
   n_implementation_periods = c(1)


### PR DESCRIPTION
Stops `optic_simulation()` early with an informative message when the input data contains NAs in any column it must use across all models: `unit_var`, `time_var`, formula LHS (outcome), and formula RHS minus treatment-construct terms (covariates). Treatment columns are simulated by optic and are excluded.

Replaces a class of cryptic downstream errors (e.g. autoeffect's "spec_strategy out of sync" message when an NA-only `factor(date)` level is silently dropped during linear initialization) with a single upfront error that names the offending columns.

Tests, vignette, and the `optic_simulation` example were updated to drop the Dakotas (NAs in `crude.rate` in early years) so existing simulator-input patterns continue to validate cleanly.