### PR TITLE
Add other-metrics section to power vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # optic (development version)
 
+## Improvements
+
+* The power analysis vignette now includes an "Examining other metrics of performance" section showing bias, simulation variance, model-based variance, RMSE, and coverage curves alongside the existing power curves, and the summary chunk now uses `summarize_simulation()` directly to demonstrate the full set of metrics it returns.
+
+## Bug fixes
+
+* `sim_correction_factor()`, `sim_coverage()`, and `sim_correct_rejection_rate()` now return `NA_real_` (rather than `numeric(0)`) when no test statistics are available -- e.g. for methods like ASCM and CSA whose default inference does not produce a t-statistic. This lets `summarize_simulation()` run cleanly across mixed-method simulations.
+
 # [optic 1.2.6](https://github.com/RANDCorporation/optic/releases/tag/v1.2.6)
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,12 @@
 
 ## Improvements
 
-* The power analysis vignette now includes an "Examining other metrics of performance" section showing bias, simulation variance, model-based variance, RMSE, and coverage curves alongside the existing power curves, and the summary chunk now uses `summarize_simulation()` directly to demonstrate the full set of metrics it returns.
+* The power analysis vignette now includes an "Examining other metrics of performance" section showing bias, simulation variance, model-based variance, relative RMSE, and coverage curves alongside the existing power curves, and the summary chunk now uses `summarize_simulation()` directly to demonstrate the full set of metrics it returns. Bias and RMSE are reported as a percentage of the outcome mean.
+* `summarize_simulation()` now falls back to an uncorrected 95% CI when no t-statistics are available, so coverage and `correct_rejection_rate` are populated for methods like ASCM and CSA whose default inference does not produce a t-statistic.
 
 ## Bug fixes
 
-* `sim_correction_factor()`, `sim_coverage()`, and `sim_correct_rejection_rate()` now return `NA_real_` (rather than `numeric(0)`) when no test statistics are available -- e.g. for methods like ASCM and CSA whose default inference does not produce a t-statistic. This lets `summarize_simulation()` run cleanly across mixed-method simulations.
+* `sim_correction_factor()`, `sim_coverage()`, and `sim_correct_rejection_rate()` now return `NA_real_` (rather than `numeric(0)`) when no test statistics are available, replacing a confusing zero-length result with an explicit missing value.
 
 # [optic 1.2.6](https://github.com/RANDCorporation/optic/releases/tag/v1.2.6)
 

--- a/R/performance-stats.R
+++ b/R/performance-stats.R
@@ -56,6 +56,7 @@ sim_mse <- function(estimates, true_effect) {
 #' @export
 sim_correction_factor <- function(test_stats) {
   test_stats <- test_stats[!is.na(test_stats)]
+  if (length(test_stats) == 0) return(NA_real_)
   f_stats <- sort(test_stats^2)
   femp95 <- f_stats[floor(0.95 * length(f_stats))]
   freal <- stats::qf(0.95, 1, Inf)
@@ -78,6 +79,7 @@ sim_correction_factor <- function(test_stats) {
 #' @export
 sim_coverage <- function(estimates, ses, true_effect = 0,
                          correction_factor = 1, alpha = 0.05) {
+  if (is.na(correction_factor)) return(NA_real_)
   adj_ses <- ses * correction_factor
   z <- stats::qnorm(1 - alpha / 2)
   low <- estimates - z * adj_ses
@@ -124,6 +126,7 @@ sim_type_s_error <- function(estimates, p_values, true_effect, alpha = 0.05) {
 #' @export
 sim_correct_rejection_rate <- function(estimates, ses, true_effect,
                                        correction_factor = 1, alpha = 0.05) {
+  if (is.na(correction_factor)) return(NA_real_)
   adj_ses <- ses * correction_factor
   z <- stats::qnorm(1 - alpha / 2)
   low <- estimates - z * adj_ses

--- a/R/performance-stats.R
+++ b/R/performance-stats.R
@@ -176,6 +176,10 @@ summarize_simulation <- function(results, true_effect,
   se_valid <- se[valid]
 
   cf <- sim_correction_factor(tstat)
+  # When no t-statistics are available (e.g. ASCM, CSA), fall back to an
+  # uncorrected 95% CI for coverage and correct-rejection rate so those
+  # methods still produce comparable values.
+  cf_for_ci <- if (is.na(cf)) 1 else cf
 
   data.frame(
     mean_estimate = mean(est_valid),
@@ -187,10 +191,10 @@ summarize_simulation <- function(results, true_effect,
     rmse = sqrt(mean(sim_mse(est_valid, true_effect))),
     rejection_rate = sim_rejection_rate(pval),
     correction_factor = cf,
-    coverage = sim_coverage(est_valid, se_valid, true_effect, cf),
+    coverage = sim_coverage(est_valid, se_valid, true_effect, cf_for_ci),
     type_s_error = sim_type_s_error(est_valid, pval[valid], true_effect),
     correct_rejection_rate = sim_correct_rejection_rate(
-      est_valid, se_valid, true_effect, cf
+      est_valid, se_valid, true_effect, cf_for_ci
     ),
     n_valid = sum(valid)
   )

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -222,7 +222,9 @@ summary_df <- results_filtered %>%
       effect_magnitude == 0,
       rejection_rate,
       rejection_rate * (1 - type_s_error)
-    )
+    ),
+    bias_pct = mean_bias / outcome_mean * 100,
+    rmse_pct = rmse / outcome_mean * 100
   )
 ```
 
@@ -279,7 +281,7 @@ summary_df %>%
 
 # Examining other metrics of performance
 
-Power tells us how often a method rejects the null in the right direction, but it is not the only thing worth tracking. Bias measures whether the point estimate is systematically off from the true effect. Simulation variance is the empirical spread of estimates across Monte Carlo iterations. Model-based variance is the average of the variances each fit reports for itself; comparing the two reveals whether reported standard errors match the actual sampling distribution. RMSE combines bias and variance into a single accuracy summary, and coverage measures how often the 95% confidence interval contains the truth.
+Power tells us how often a method rejects the null in the right direction, but it is not the only thing worth tracking. Bias measures whether the point estimate is systematically off from the true effect. Simulation variance is the empirical spread of estimates across Monte Carlo iterations. Model-based variance is the average of the variances each fit reports for itself; comparing the two reveals whether reported standard errors match the actual sampling distribution. Relative RMSE combines bias and variance into a single accuracy summary, expressed as a percentage of the outcome mean, and coverage measures how often the 95% confidence interval contains the truth.
 
 All of these are returned by the same `summarize_simulation()` call used above. The plots below replace the y-axis of the power curves with each metric in turn, so panels are directly comparable across number of treated units and effect size.
 
@@ -313,10 +315,10 @@ metric_plot <- function(df, y, ylab, hline = NULL) {
 
 ## Bias
 
-Bias is the average difference between the point estimate and the true effect. A well-calibrated estimator should have bias near zero across all scenarios.
+Bias is the average difference between the point estimate and the true effect. A well-calibrated estimator should have bias near zero across all scenarios. We express it in percentage points relative to the outcome mean so it is comparable to the effect-size axis.
 
 ```{r bias-curves, fig.width = 8, fig.height = 5}
-metric_plot(summary_df, "mean_bias", "Bias", hline = 0)
+metric_plot(summary_df, "bias_pct", "Bias (% of outcome mean)", hline = 0)
 ```
 
 ## Simulation variance
@@ -335,12 +337,12 @@ Model-based variance is the average of the variances reported by each fit. Where
 metric_plot(summary_df, "mean_variance", "Model-based variance")
 ```
 
-## RMSE
+## Relative RMSE
 
-Root mean squared error combines bias and variance into a single measure of estimation accuracy.
+Root mean squared error combines bias and variance into a single measure of estimation accuracy. We report it relative to the outcome mean (in percentage points).
 
 ```{r rmse-curves, fig.width = 8, fig.height = 5}
-metric_plot(summary_df, "rmse", "RMSE")
+metric_plot(summary_df, "rmse_pct", "Relative RMSE (% of outcome mean)")
 ```
 
 ## Coverage

--- a/vignettes/power_analysis.Rmd
+++ b/vignettes/power_analysis.Rmd
@@ -189,7 +189,9 @@ results <- readRDS(rds_path)
 
 ## Summarize results
 
-For each combination of model, effect size, and number of treated units, we compute the rejection rate, Type S error, and correct-direction power. For TWFE and Debiased AR, which produce both unadjusted and cluster-robust results, we keep only the cluster-robust rows. ASCM and CSA report a single SE adjustment ("none"), which is their default inference.
+For each combination of model, effect size, and number of treated units, we compute a full set of performance metrics in a single call to `summarize_simulation()`. This exported helper returns one row per scenario with columns including `mean_bias`, `mean_variance` (the average of the model-reported variances), `simulated_variance` (the empirical variance of estimates across iterations), `rmse`, `coverage`, `rejection_rate`, and `type_s_error`. We use these downstream both for power and for the additional metrics shown in the final section.
+
+For TWFE and Debiased AR, which produce both unadjusted and cluster-robust results, we keep only the cluster-robust rows. ASCM and CSA report a single SE adjustment ("none"), which is their default inference.
 
 ```{r summarize}
 available_models <- unique(results$model_name)
@@ -202,23 +204,14 @@ results_filtered <- results %>%
     (model_name %in% c("ASCM", "CSA") & se_adjustment == "none")
   )
 
-
 summary_df <- results_filtered %>%
   group_by(model_name, n_units, effect_magnitude, effect_direction) %>%
-  summarize(
-    rejection_rate = sim_rejection_rate(p_value),
-    type_s_error = sim_type_s_error(
-      estimate, p_value,
-      true_effect = if (first(effect_direction) == "neg") {
-        -first(effect_magnitude)
-      } else {
-        first(effect_magnitude)
-      }
-    ),
-    mean_estimate = mean(estimate, na.rm = TRUE),
-    mean_se = mean(se, na.rm = TRUE),
-    .groups = "drop"
-  ) %>%
+  group_modify(~ summarize_simulation(
+    .x,
+    true_effect = if (.y$effect_direction == "neg") -.y$effect_magnitude
+                  else .y$effect_magnitude
+  )) %>%
+  ungroup() %>%
   mutate(
     effect_pct = round(effect_magnitude / outcome_mean * 100),
     n_units_label = factor(
@@ -282,6 +275,80 @@ summary_df %>%
   tidyr::pivot_wider(names_from = n_units, values_from = rejection_rate,
                      names_prefix = "N=") %>%
   knitr::kable(digits = 3, caption = "Type I error rate by model and N treated")
+```
+
+# Examining other metrics of performance
+
+Power tells us how often a method rejects the null in the right direction, but it is not the only thing worth tracking. Bias measures whether the point estimate is systematically off from the true effect. Simulation variance is the empirical spread of estimates across Monte Carlo iterations. Model-based variance is the average of the variances each fit reports for itself; comparing the two reveals whether reported standard errors match the actual sampling distribution. RMSE combines bias and variance into a single accuracy summary, and coverage measures how often the 95% confidence interval contains the truth.
+
+All of these are returned by the same `summarize_simulation()` call used above. The plots below replace the y-axis of the power curves with each metric in turn, so panels are directly comparable across number of treated units and effect size.
+
+```{r metric-helper, include = FALSE}
+metric_plot <- function(df, y, ylab, hline = NULL) {
+  p <- ggplot(
+    df,
+    aes(x = effect_pct, y = .data[[y]], color = model_name,
+        shape = model_name, group = model_name)
+  ) +
+    geom_line(linewidth = 0.8) +
+    geom_point(size = 2.5) +
+    facet_wrap(~n_units_label, nrow = 1) +
+    scale_color_manual(values = model_colors, name = NULL) +
+    scale_shape_manual(values = model_shapes, name = NULL) +
+    scale_x_continuous(breaks = unique(df$effect_pct)) +
+    labs(x = "Effect size (% of outcome mean)", y = ylab) +
+    theme_minimal() +
+    theme(
+      strip.text = element_text(face = "bold"),
+      legend.position = "bottom",
+      panel.grid.minor = element_blank()
+    )
+  if (!is.null(hline)) {
+    p <- p + geom_hline(yintercept = hline, linetype = "dashed",
+                        color = "gray50")
+  }
+  p
+}
+```
+
+## Bias
+
+Bias is the average difference between the point estimate and the true effect. A well-calibrated estimator should have bias near zero across all scenarios.
+
+```{r bias-curves, fig.width = 8, fig.height = 5}
+metric_plot(summary_df, "mean_bias", "Bias", hline = 0)
+```
+
+## Simulation variance
+
+Simulation variance is the empirical variance of the point estimates across iterations -- a Monte Carlo estimate of the true sampling variance of each method.
+
+```{r sim-variance-curves, fig.width = 8, fig.height = 5}
+metric_plot(summary_df, "simulated_variance", "Simulation variance")
+```
+
+## Model-based variance
+
+Model-based variance is the average of the variances reported by each fit. Where this differs from the simulation variance above, the model's standard errors are mis-calibrated relative to the true sampling distribution.
+
+```{r model-variance-curves, fig.width = 8, fig.height = 5}
+metric_plot(summary_df, "mean_variance", "Model-based variance")
+```
+
+## RMSE
+
+Root mean squared error combines bias and variance into a single measure of estimation accuracy.
+
+```{r rmse-curves, fig.width = 8, fig.height = 5}
+metric_plot(summary_df, "rmse", "RMSE")
+```
+
+## Coverage
+
+Coverage is the proportion of 95% confidence intervals that contain the true effect. A well-calibrated method should sit near 0.95 across scenarios.
+
+```{r coverage-curves, fig.width = 8, fig.height = 5}
+metric_plot(summary_df, "coverage", "Coverage", hline = 0.95)
 ```
 
 # Conclusion


### PR DESCRIPTION
Adds a new section showing bias, simulation variance, model-based variance, RMSE, and coverage curves alongside the existing power curves, and refactors the summary chunk to use `summarize_simulation()` so all metrics come from one call. Also fixes `sim_correction_factor()` / `sim_coverage()` / `sim_correct_rejection_rate()` to return `NA_real_` (not `numeric(0)`) when no t-statistics are available, which was breaking ASCM/CSA scenarios.