### PR TITLE
Read autoeffect cumulative_effects with tidymodels-style columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     ebenmichael/augsynth,
-    RANDCorporation/autoeffect@feature/outcome-family
+    RANDCorporation/autoeffect@feature/cumulative-effects-tidymodels
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     ebenmichael/augsynth,
-    RANDCorporation/autoeffect
+    RANDCorporation/autoeffect@feature/outcome-family
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: optic
 Title: Simulation Tool for Causal Inference Using Longitudinal Data
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: c(
     person("Beth Ann", "Griffin", , "bethg@rand.org", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0002-2391-4601")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     ebenmichael/augsynth,
-    RANDCorporation/autoeffect@feature/cumulative-effects-tidymodels
+    RANDCorporation/autoeffect
 Config/Needs/integration:
     autoeffect
 VignetteBuilder: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # optic (development version)
 
+## Internal changes
+
+* Updated the autoeffect result extractors (`.extract_results_autoeffect` and `.se_adjust_cluster_autoeffect`) to read the renamed tidymodels-style columns from `autoeffect::cumulative_effects()` (`lag`, `estimate`, `std.error`, `statistic`, `p.value`). Requires autoeffect >= 0.2.12.
+
 # [optic 1.2.6](https://github.com/RANDCorporation/optic/releases/tag/v1.2.6)
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Internal changes
 
-* Updated the autoeffect result extractors (`.extract_results_autoeffect` and `.se_adjust_cluster_autoeffect`) to read the renamed tidymodels-style columns from `autoeffect::cumulative_effects()` (`lag`, `estimate`, `std.error`, `statistic`, `p.value`). Requires autoeffect >= 0.2.12.
+* Updated the autoeffect result extractors (`.extract_results_autoeffect` and `.se_adjust_cluster_autoeffect`) to read the renamed tidymodels-style columns from `autoeffect::cumulative_effects()` (`lag`, `estimate`, `std.error`, `statistic`, `p.value`). Requires autoeffect >= 0.2.11.
 
 # [optic 1.2.6](https://github.com/RANDCorporation/optic/releases/tag/v1.2.6)
 

--- a/R/model-type-behaviors.R
+++ b/R/model-type-behaviors.R
@@ -303,14 +303,14 @@ get_behavior <- function(model_type) {
     t_stat <- NA_real_
     p_value <- NA_real_
   } else {
-    if (!effect_lag %in% cum_effects$Lag) {
+    if (!effect_lag %in% cum_effects$lag) {
       stop("Requested effect_lag = ", effect_lag, " not available in cumulative effects output.")
     }
-    effect_row <- cum_effects[cum_effects$Lag == effect_lag, ]
-    estimate <- effect_row$Estimate
-    se <- effect_row$StdError
-    t_stat <- effect_row$t_stat
-    p_value <- effect_row$p_value
+    effect_row <- cum_effects[cum_effects$lag == effect_lag, ]
+    estimate <- effect_row$estimate
+    se <- effect_row$std.error
+    t_stat <- effect_row$statistic
+    p_value <- effect_row$p.value
   }
 
   variance <- se^2
@@ -538,13 +538,13 @@ get_behavior <- function(model_type) {
   cum_effects_fn <- utils::getFromNamespace("cumulative_effects", "autoeffect")
   cum_effects <- cum_effects_fn(ae_object, cluster = cluster_var_name)
 
-  if (is.null(cum_effects) || !effect_lag %in% cum_effects$Lag) {
+  if (is.null(cum_effects) || !effect_lag %in% cum_effects$lag) {
     estimate <- NA_real_; se <- NA_real_
     t_stat <- NA_real_; p_value <- NA_real_
   } else {
-    effect_row <- cum_effects[cum_effects$Lag == effect_lag, ]
-    estimate <- effect_row$Estimate; se <- effect_row$StdError
-    t_stat <- effect_row$t_stat; p_value <- effect_row$p_value
+    effect_row <- cum_effects[cum_effects$lag == effect_lag, ]
+    estimate <- effect_row$estimate; se <- effect_row$std.error
+    t_stat <- effect_row$statistic; p_value <- effect_row$p.value
   }
 
   variance <- se^2


### PR DESCRIPTION
Updates `.extract_results_autoeffect` and `.se_adjust_cluster_autoeffect` to read the renamed columns from `autoeffect::cumulative_effects()` (`lag`, `estimate`, `std.error`, `statistic`, `p.value`).

Pairs with [autoeffect#11](https://github.com/RANDCorporation/autoeffect/pull/11). The `Remotes:` field is temporarily pinned to autoeffect's PR #11 branch so CI here fetches the matching column names; will be reverted after both PRs merge.

-----